### PR TITLE
Weight benchmark speedups by kernel cost

### DIFF
--- a/dashboard/onnx-light/benchmark.html
+++ b/dashboard/onnx-light/benchmark.html
@@ -280,18 +280,17 @@ table.benchmark tr.graph-row > td {
     <a href="../../docs/onnx-light-cpu/index.html"><code>onnx&#8209;light&#8209;cpu</code></a>
     SIMD kernels layered on top, and its speedup uses the same
     <code>onnxruntime&nbsp;avg</code> baseline.
-    The <em>avg speedup</em> card is the unweighted mean of every
+    Three averages are reported. <em>Avg speedup</em> is the unweighted mean of every
     per-test speedup, so an O(1) kernel (e.g.
     <code>Shape</code>/<code>Reshape</code>) counts as much as an O(n)
     (<code>Add</code>) or O(n&sup2;) (<code>Gemm</code>) one; the
     <em>weighted avg speedup</em> card instead weighs each test by a
-    symbolic cost <code>N</code> &mdash; the number of scalar elements in
-    its input/output tensors, a size-based proxy for kernel cost that does
-    not depend on any backend's measured execution time
+    symbolic kernel cost: linear in tensor size for ordinary unary/binary
+    operators and quadratic for matrix multiplication and attention
     (<code>sum(N&nbsp;&times;&nbsp;speedup)&nbsp;/&nbsp;sum(N)</code>),
-    giving more weight to tests that process more data. The weight
-    <code>N</code> attributed to each operator (summed across its tests) is
-    listed in the collapsible table below the summary cards.
+    while <em>sum latency speedup</em> is
+    <code>sum(baseline latency)&nbsp;/&nbsp;sum(backend latency)</code>.
+    Each row shows its symbolic weight.
   </p>
 </header>
 <div class="notice" style="max-width:1100px;width:100%;margin:0 auto 1em;padding:0.5em 1em;border-radius:8px;background:rgba(210,153,34,0.12);border:1px solid rgba(210,153,34,0.5);color:#d29922;font-size:0.85em;text-align:center;box-sizing:border-box;">⚠ The results displayed on this page are indicative and experimental.</div>
@@ -308,7 +307,7 @@ table.benchmark tr.graph-row > td {
   <div id="operatorWeightsPanel" style="display:none;margin-top:0.8em;">
     <details>
       <summary style="cursor:pointer;color:#8b949e;font-size:0.85em;">
-        weight (symbolic <code>N</code>) used per operator in <em>weighted avg speedup</em>
+        symbolic weight used per operator in <em>weighted avg speedup</em>
       </summary>
       <div class="table-wrap" style="margin-top:0.5em;">
         <table class="benchmark" id="operatorWeightsTable">
@@ -316,7 +315,7 @@ table.benchmark tr.graph-row > td {
             <tr>
               <th>operator</th>
               <th class="center">tests</th>
-              <th class="center">total weight (N)</th>
+              <th class="center">total weight</th>
               <th class="center">share</th>
             </tr>
           </thead>
@@ -360,19 +359,21 @@ table.benchmark tr.graph-row > td {
   <div class="table-wrap">
     <table class="benchmark">
       <colgroup>
-        <col style="width:22%" />
+        <col style="width:19%" />
+        <col style="width:8%" />
         <col style="width:9%" />
-        <col style="width:11%" />
-        <col style="width:11%" />
-        <col style="width:11%" />
-        <col style="width:9%" />
-        <col style="width:9%" />
+        <col style="width:10%" />
+        <col style="width:10%" />
+        <col style="width:10%" />
+        <col style="width:8%" />
+        <col style="width:8%" />
         <col style="width:18%" />
       </colgroup>
       <thead>
         <tr>
           <th data-key="name">Test <span class="arrow"></span></th>
           <th data-key="input_type" class="center">input type <span class="arrow"></span></th>
+          <th data-key="cost_n" class="center">weight <span class="arrow"></span></th>
           <th data-key="onnxruntime_avg_ms" class="center"><code>onnxruntime</code> avg <span class="arrow"></span></th>
           <th data-key="onnx_light_avg_ms" class="center"><code>onnx-light</code> avg <span class="arrow"></span></th>
           <th data-key="onnx_light_cpu_avg_ms" class="center"><code>onnx-light + cpu</code> avg <span class="arrow"></span></th>
@@ -440,13 +441,39 @@ function renderMeta(payload) {
     (payload.n_measure || 10) + " timed iteration(s) per test.";
 
   renderSummaryCards(payload.summary || {}, payload.tests || [], payload.n_warmup, payload.n_measure);
-  renderOperatorWeights(payload.summary || {});
+  renderOperatorWeights(payload.summary || {}, payload.tests || []);
 }
 
-function renderOperatorWeights(summary) {
+const QUADRATIC_COST_OPERATORS = new Set([
+  "Attention", "Gemm", "MatMul", "MatMulInteger", "MultiHeadAttention",
+  "QAttention", "QLinearMatMul"
+]);
+
+function rowWeight(row) {
+  if (row.cost_n === undefined || row.cost_n === null) return null;
+  if (row.cost_complexity) return row.cost_n;
+  const operators = String(row.operator || "").split("+");
+  return operators.some(op => QUADRATIC_COST_OPERATORS.has(op))
+    ? row.cost_n * row.cost_n
+    : row.cost_n;
+}
+
+function renderOperatorWeights(summary, rows) {
   const panel = document.getElementById("operatorWeightsPanel");
   const body = document.getElementById("operatorWeightsBody");
-  const weights = summary.operator_weights;
+  const grouped = new Map();
+  for (const row of rows) {
+    const operator = row.operator || "";
+    const weight = rowWeight(row);
+    if (!operator || weight === null || weight <= 0) continue;
+    const entry = grouped.get(operator) || { operator, weight: 0, tests: 0 };
+    entry.weight += weight;
+    entry.tests += 1;
+    grouped.set(operator, entry);
+  }
+  const weights = grouped.size
+    ? Array.from(grouped.values()).sort((a, b) => b.weight - a.weight)
+    : summary.operator_weights;
   body.innerHTML = "";
   if (!weights || !weights.length) {
     panel.style.display = "none";
@@ -490,6 +517,32 @@ function renderSummaryCards(summary, rows, nWarmup, nMeasure) {
   const nSlower = rows.filter(r => r.speedup !== undefined && r.speedup < 1).length;
   const avgSpeedup = summary.avg_speedup;
 
+  function weightedAverage(speedupKey) {
+    let weightedTotal = 0;
+    let weightTotal = 0;
+    for (const row of rows) {
+      const speedup = row[speedupKey];
+      const weight = rowWeight(row);
+      if (speedup === undefined || weight === null || weight <= 0) continue;
+      weightedTotal += speedup * weight;
+      weightTotal += weight;
+    }
+    return weightTotal > 0 ? weightedTotal / weightTotal : undefined;
+  }
+
+  function sumLatencySpeedup(backendKey) {
+    let baselineTotal = 0;
+    let backendTotal = 0;
+    for (const row of rows) {
+      const baseline = row.onnxruntime_avg_ms;
+      const backend = row[backendKey];
+      if (baseline === undefined || backend === undefined || backend <= 0) continue;
+      baselineTotal += baseline;
+      backendTotal += backend;
+    }
+    return backendTotal > 0 ? baselineTotal / backendTotal : undefined;
+  }
+
   function addCard(cls, label, value, detail) {
     const card = document.createElement("div");
     card.className = "summary-card " + cls;
@@ -506,10 +559,17 @@ function renderSummaryCards(summary, rows, nWarmup, nMeasure) {
     const cls = avgSpeedup >= 1 ? "faster" : (avgSpeedup >= 0.9 ? "close" : "slower");
     addCard(cls, "avg speedup (ort / light)", avgSpeedup.toFixed(2) + "×", "unweighted mean of per-test speedups");
   }
-  const avgSpeedupWeighted = summary.avg_speedup_weighted;
+  const avgSpeedupWeighted = weightedAverage("speedup");
   if (avgSpeedupWeighted !== undefined) {
     const clsW = avgSpeedupWeighted >= 1 ? "faster" : (avgSpeedupWeighted >= 0.9 ? "close" : "slower");
-    addCard(clsW, "weighted avg speedup (ort / light)", avgSpeedupWeighted.toFixed(2) + "×", "weighted by a symbolic size N (input/output element count), i.e. kernel cost");
+    addCard(clsW, "weighted avg speedup (ort / light)", avgSpeedupWeighted.toFixed(2) + "×", "linear cost for ordinary kernels; quadratic for matrix multiplication and attention");
+  }
+  const sumLatency = summary.speedup_sum_latency !== undefined
+    ? summary.speedup_sum_latency
+    : sumLatencySpeedup("onnx_light_avg_ms");
+  if (sumLatency !== undefined) {
+    const clsSum = sumLatency >= 1 ? "faster" : (sumLatency >= 0.9 ? "close" : "slower");
+    addCard(clsSum, "sum latency speedup (ort / light)", sumLatency.toFixed(2) + "×", "sum(onnxruntime latency) / sum(onnx-light latency)");
   }
   addCard("faster", "onnx-light faster", String(nFaster), "of " + bothOk + " jointly successful");
   addCard("slower", "onnx-light slower", String(nSlower), "of " + bothOk + " jointly successful");
@@ -518,10 +578,17 @@ function renderSummaryCards(summary, rows, nWarmup, nMeasure) {
     const clsCpu = avgSpeedupCpu >= 1 ? "faster" : (avgSpeedupCpu >= 0.9 ? "close" : "slower");
     addCard(clsCpu, "avg speedup (ort / light+cpu)", avgSpeedupCpu.toFixed(2) + "×", "onnx-light with onnx-light-cpu kernels vs onnxruntime");
   }
-  const avgSpeedupWeightedCpu = summary.avg_speedup_weighted_cpu;
+  const avgSpeedupWeightedCpu = weightedAverage("speedup_cpu");
   if (avgSpeedupWeightedCpu !== undefined) {
     const clsWCpu = avgSpeedupWeightedCpu >= 1 ? "faster" : (avgSpeedupWeightedCpu >= 0.9 ? "close" : "slower");
-    addCard(clsWCpu, "weighted avg speedup (ort / light+cpu)", avgSpeedupWeightedCpu.toFixed(2) + "×", "weighted by a symbolic size N (input/output element count), i.e. kernel cost");
+    addCard(clsWCpu, "weighted avg speedup (ort / light+cpu)", avgSpeedupWeightedCpu.toFixed(2) + "×", "linear cost for ordinary kernels; quadratic for matrix multiplication and attention");
+  }
+  const sumLatencyCpu = summary.speedup_sum_latency_cpu !== undefined
+    ? summary.speedup_sum_latency_cpu
+    : sumLatencySpeedup("onnx_light_cpu_avg_ms");
+  if (sumLatencyCpu !== undefined) {
+    const clsSumCpu = sumLatencyCpu >= 1 ? "faster" : (sumLatencyCpu >= 0.9 ? "close" : "slower");
+    addCard(clsSumCpu, "sum latency speedup (ort / light+cpu)", sumLatencyCpu.toFixed(2) + "×", "sum(onnxruntime latency) / sum(onnx-light+cpu latency)");
   }
   if (nWarmup !== undefined) addCard("neutral", "warm-up iterations", String(nWarmup), "not timed");
   if (nMeasure !== undefined) addCard("neutral", "timed iterations", String(nMeasure), "per test");
@@ -633,6 +700,7 @@ function compareRows(a, b) {
   let va = a[key];
   let vb = b[key];
   if (key === "status") { va = rowStatus(a); vb = rowStatus(b); }
+  if (key === "cost_n") { va = rowWeight(a); vb = rowWeight(b); }
   let cmp;
   if (va === undefined || va === null) cmp = (vb === undefined || vb === null) ? 0 : -1;
   else if (vb === undefined || vb === null) cmp = 1;
@@ -753,7 +821,7 @@ function renderRows() {
     const tr = document.createElement("tr");
     tr.className = "empty-row";
     const td = document.createElement("td");
-    td.colSpan = 8;
+    td.colSpan = 9;
     td.textContent = state.regexError
       ? "Fix the filter regex to see results."
       : state.search ? "No test matches the current filter." : "No test recorded.";
@@ -783,6 +851,21 @@ function renderRows() {
         inputTypeTd.appendChild(code);
       } else {
         inputTypeTd.textContent = "—";
+      }
+
+      /* Symbolic kernel weight */
+      const weightTd = document.createElement("td");
+      weightTd.className = "center";
+      const weight = rowWeight(r);
+      if (weight !== null) {
+        weightTd.textContent = weight.toLocaleString();
+        weightTd.title = (r.cost_complexity || (
+          String(r.operator || "").split("+").some(op => QUADRATIC_COST_OPERATORS.has(op))
+            ? "quadratic"
+            : "linear"
+        )) + " symbolic cost";
+      } else {
+        weightTd.textContent = "—";
       }
 
       /* onnxruntime avg */
@@ -856,6 +939,7 @@ function renderRows() {
 
       tr.appendChild(nameTd);
       tr.appendChild(inputTypeTd);
+      tr.appendChild(weightTd);
       tr.appendChild(ortTd);
       tr.appendChild(lightTd);
       tr.appendChild(cpuTd);
@@ -863,7 +947,7 @@ function renderRows() {
       tr.appendChild(speedupCpuTd);
       tr.appendChild(statusTd);
 
-      const graphRow = appendGraphRow(tr, nameTd, r, 8);
+      const graphRow = appendGraphRow(tr, nameTd, r, 9);
       body.appendChild(tr);
       if (graphRow) body.appendChild(graphRow);
     }

--- a/scripts/record_onnx_light_benchmark.py
+++ b/scripts/record_onnx_light_benchmark.py
@@ -34,11 +34,13 @@ For each test the measurement protocol is:
 
    A speedup > 1 indicates that ``onnx-light`` is faster than
    ``onnxruntime`` on that test case.
-5. Aggregate two summary averages: ``avg_speedup`` is the unweighted mean
+5. Aggregate three summary averages: ``avg_speedup`` is the unweighted mean
    of every per-test ``speedup`` ratio, while ``avg_speedup_weighted`` is
    ``sum(N_i * speedup_i) / sum(N_i)`` across those same tests, where
-   ``N_i`` is a symbolic per-test cost estimate (the number of scalar
-   elements in the test's input/output tensors, see ``_symbolic_cost``).
+   ``N_i`` is a symbolic per-test cost estimate (linear in tensor size for
+   ordinary unary/binary kernels and quadratic for matrix multiplication and
+   attention, see ``_symbolic_cost``). ``speedup_sum_latency`` is
+   ``sum(onnxruntime_avg_ms) / sum(onnx_light_avg_ms)``.
    The unweighted mean treats every kernel equally regardless of its
    actual cost, so an O(1) kernel (``Shape``, ``Reshape``, ...) counts as
    much as an O(n) (``Add``) or O(n^2) (``Gemm``) one; the weighted
@@ -862,18 +864,35 @@ def _count_elements(value: Any) -> int:
     return 1
 
 
-def _symbolic_cost(data_sets: List[Tuple[List[Any], List[Any]]]) -> Optional[int]:
+QUADRATIC_COST_OPERATORS = frozenset(
+    {
+        "Attention",
+        "Gemm",
+        "MatMul",
+        "MatMulInteger",
+        "MultiHeadAttention",
+        "QAttention",
+        "QLinearMatMul",
+    }
+)
+
+
+def _cost_complexity(operator: str) -> str:
+    """Return the complexity class used to weight ``operator``."""
+    operators = set(operator.split("+"))
+    return "quadratic" if operators & QUADRATIC_COST_OPERATORS else "linear"
+
+
+def _symbolic_cost(
+    data_sets: List[Tuple[List[Any], List[Any]]], operator: str = ""
+) -> Optional[int]:
     """Return a symbolic complexity estimate ``N`` for a test's first data set.
 
-    ``N`` is the total number of scalar elements across the test's input and
-    output tensors (or, for sequence/map values, the sum of the element
-    counts of their nested values). It is a *symbolic* size, derived purely
-    from the shapes of the data used by the test, not from any measured
-    execution time — an O(1) kernel (e.g. ``Shape``/``Reshape``) applied to a
-    huge tensor still touches every element of that tensor and gets a large
-    ``N`` here, but the point is only to approximate how much data a kernel
-    processes so bigger kernels are weighed more than trivial ones, without
-    depending on how fast any particular backend happens to run.
+    The base size is the total number of scalar input/output elements. Unary,
+    binary, and other ordinary kernels receive that linear weight. Matrix
+    multiplication and attention kernels receive its square, reflecting the
+    requested quadratic cost model. The estimate depends only on test shapes,
+    never on a backend's measured execution time.
     """
     if not data_sets:
         return None
@@ -881,8 +900,10 @@ def _symbolic_cost(data_sets: List[Tuple[List[Any], List[Any]]]) -> Optional[int
         inputs, outputs = data_sets[0]
     except (ValueError, TypeError):
         return None
-    total = _count_elements(list(inputs)) + _count_elements(list(outputs))
-    return total or None
+    size = _count_elements(list(inputs)) + _count_elements(list(outputs))
+    if not size:
+        return None
+    return size**2 if _cost_complexity(operator) == "quadratic" else size
 
 
 def _operator_name(model: Any) -> str:
@@ -956,12 +977,31 @@ def _weighted_avg_speedup(
     return round(weighted_total / weight_total, 4)
 
 
+def _sum_latency_speedup(
+    rows: List[Dict[str, Any]], backend_key: str
+) -> Optional[float]:
+    """Return ``sum(baseline latency) / sum(backend latency)``."""
+    baseline_total = 0.0
+    backend_total = 0.0
+    for row in rows:
+        baseline = row.get("onnxruntime_avg_ms")
+        backend = row.get(backend_key)
+        if baseline is None or backend is None or backend <= 0:
+            continue
+        baseline_total += baseline
+        backend_total += backend
+    if backend_total <= 0:
+        return None
+    return round(baseline_total / backend_total, 4)
+
+
 def _row_from_results(
     name: str,
     results: Dict[str, Dict[str, Any]],
     tag: str = "",
     graph: Optional[Dict[str, Any]] = None,
     cost_n: Optional[int] = None,
+    cost_complexity: str = "",
     operator: str = "",
     input_type: str = "",
 ) -> Dict[str, Any]:
@@ -973,6 +1013,8 @@ def _row_from_results(
         row["graph"] = graph
     if cost_n is not None:
         row["cost_n"] = cost_n
+    if cost_complexity:
+        row["cost_complexity"] = cost_complexity
     if operator:
         row["operator"] = operator
     if input_type:
@@ -1092,8 +1134,9 @@ def build_payload(
         except Exception:  # noqa: BLE001
             graph = None
 
-        cost_n = _symbolic_cost(data_sets)
         operator = _operator_name(model)
+        cost_complexity = _cost_complexity(operator)
+        cost_n = _symbolic_cost(data_sets, operator)
         input_type = _first_input_type(data_sets)
 
         results: Dict[str, Dict[str, Any]] = {}
@@ -1107,6 +1150,7 @@ def build_payload(
                 "graph": graph,
                 "results": results,
                 "cost_n": cost_n,
+                "cost_complexity": cost_complexity,
                 "operator": operator,
                 "input_type": input_type,
             }
@@ -1132,6 +1176,7 @@ def build_payload(
             tag=entry["tag"],
             graph=entry["graph"],
             cost_n=entry["cost_n"],
+            cost_complexity=entry["cost_complexity"],
             operator=entry["operator"],
             input_type=entry["input_type"],
         )
@@ -1152,6 +1197,9 @@ def build_payload(
     weighted = _weighted_avg_speedup(both_ok, "speedup")
     if weighted is not None:
         summary["avg_speedup_weighted"] = weighted
+    sum_latency = _sum_latency_speedup(both_ok, "onnx_light_avg_ms")
+    if sum_latency is not None:
+        summary["speedup_sum_latency"] = sum_latency
     operator_weights = _operator_weights(both_ok)
     if operator_weights:
         summary["operator_weights"] = operator_weights
@@ -1171,6 +1219,9 @@ def build_payload(
     weighted_cpu = _weighted_avg_speedup(cpu_ok, "speedup_cpu")
     if weighted_cpu is not None:
         summary["avg_speedup_weighted_cpu"] = weighted_cpu
+    sum_latency_cpu = _sum_latency_speedup(cpu_ok, "onnx_light_cpu_avg_ms")
+    if sum_latency_cpu is not None:
+        summary["speedup_sum_latency_cpu"] = sum_latency_cpu
 
     return {
         "date": now_iso,

--- a/scripts/tests/test_benchmark_dashboard.py
+++ b/scripts/tests/test_benchmark_dashboard.py
@@ -44,6 +44,15 @@ class TestBenchmarkDashboard(unittest.TestCase):
         self.assertIn("table-layout: fixed;", text)
         self.assertIn("<colgroup>", text)
 
+    def test_weight_and_three_speedup_averages_are_present(self):
+        text = _read(PAGE)
+        self.assertIn('data-key="cost_n"', text)
+        self.assertIn("rowWeight(r)", text)
+        self.assertIn("weighted avg speedup (ort / light)", text)
+        self.assertIn("sum latency speedup (ort / light)", text)
+        self.assertIn("sum(onnxruntime latency) / sum(onnx-light latency)", text)
+        self.assertIn('"Attention", "Gemm", "MatMul"', text)
+
     def test_speedup_near_one_uses_distinct_color(self):
         text = _read(PAGE)
         # A speed-up in [0.9, 1[ is coloured purple, neither red nor green,

--- a/scripts/tests/test_record_onnx_light_benchmark.py
+++ b/scripts/tests/test_record_onnx_light_benchmark.py
@@ -440,6 +440,18 @@ class TestSymbolicCost(unittest.TestCase):
         # 2*3 + 4 + 5*5 = 6 + 4 + 25 = 35
         self.assertEqual(rlb._symbolic_cost(data_sets), 35)
 
+    def test_matrix_multiplication_and_attention_are_quadratic(self):
+        data_sets = [([np.zeros((2, 3)), np.zeros((3, 4))], [np.zeros((2, 4))])]
+        size = 6 + 12 + 8
+        for operator in ("MatMul", "Gemm", "Attention", "QLinearMatMul"):
+            with self.subTest(operator=operator):
+                self.assertEqual(rlb._symbolic_cost(data_sets, operator), size**2)
+
+    def test_unary_and_binary_operators_are_linear(self):
+        data_sets = [([np.zeros((8,)), np.zeros((8,))], [np.zeros((8,))])]
+        self.assertEqual(rlb._symbolic_cost(data_sets, "Abs"), 24)
+        self.assertEqual(rlb._symbolic_cost(data_sets, "Add"), 24)
+
     def test_only_uses_first_data_set(self):
         small = ([np.zeros((1,))], [np.zeros((1,))])
         big = ([np.zeros((100,))], [np.zeros((100,))])
@@ -558,6 +570,23 @@ class TestWeightedAvgSpeedup(unittest.TestCase):
         self.assertAlmostEqual(weighted, 4.0, places=4)
 
 
+class TestSumLatencySpeedup(unittest.TestCase):
+    def test_ratio_uses_sums_of_latencies(self):
+        rows = [
+            {"onnxruntime_avg_ms": 2.0, "onnx_light_avg_ms": 1.0},
+            {"onnxruntime_avg_ms": 8.0, "onnx_light_avg_ms": 4.0},
+        ]
+        self.assertEqual(rlb._sum_latency_speedup(rows, "onnx_light_avg_ms"), 2.0)
+
+    def test_skips_missing_and_invalid_latencies(self):
+        rows = [
+            {"onnxruntime_avg_ms": 2.0, "onnx_light_avg_ms": 0.0},
+            {"onnxruntime_avg_ms": 3.0},
+            {"onnxruntime_avg_ms": 8.0, "onnx_light_avg_ms": 4.0},
+        ]
+        self.assertEqual(rlb._sum_latency_speedup(rows, "onnx_light_avg_ms"), 2.0)
+
+
 def _stub_model(op_type):
     """Return a minimal object exposing ``model.graph.node[i].op_type``."""
 
@@ -651,13 +680,17 @@ class TestBuildPayload(unittest.TestCase):
         # A cost-weighted average speedup is reported alongside the
         # unweighted mean of per-test ratios.
         self.assertIn("avg_speedup_weighted", summary)
+        self.assertIn("speedup_sum_latency", summary)
         # The onnx-light-cpu backend is timed as well, so its summary and
         # per-row speedup are present too.
         self.assertEqual(summary["cpu_succeeded"], 2)
         self.assertIn("avg_speedup_cpu", summary)
         self.assertIn("avg_speedup_weighted_cpu", summary)
+        self.assertIn("speedup_sum_latency_cpu", summary)
         for row in payload["tests"]:
             self.assertIn("speedup_cpu", row, msg=row["name"])
+            self.assertIn("cost_n", row, msg=row["name"])
+            self.assertEqual(row["cost_complexity"], "linear")
 
         # Each row's operator is derived from its model's node op_type, and
         # the summary exposes the symbolic weight attributed to each


### PR DESCRIPTION
## Summary
- report simple, cost-weighted, and summed-latency speedups
- use linear weights for ordinary kernels and quadratic weights for matrix multiplication and attention
- display each test weight and preserve compatibility with existing benchmark snapshots

## Tests
- `python scripts/tests/test_record_onnx_light_benchmark.py`
- `python scripts/tests/test_benchmark_dashboard.py`