### PR TITLE
Restore full onnx-light-cpu backend coverage

### DIFF
--- a/.github/workflows/record_onnx_backend_test_coverage.yml
+++ b/.github/workflows/record_onnx_backend_test_coverage.yml
@@ -4,10 +4,11 @@ name: DATA onnx-light backend test coverage
 # ``onnx-light`` (``onnx_light.onnx_lib.backend.test.case.collect_test_case``)
 # against ``onnxruntime``, the Python reference implementation shipped
 # with ``onnx`` and the ``onnx-light`` C++ reference evaluator
-# (``onnx_light.onnx.reference``), and caches the pass/fail status as JSON
+# (``onnx_light.onnx.reference``), both before and after registering
+# ``onnx-light-cpu`` kernels, and caches the pass/fail status as JSON
 # under ``cache_data/onnx-light/backend_test_coverage.json``. The
-# dashboard at ``dashboard/onnx-light/backend-test-coverage.html``
-# consumes that file.
+# dashboards at ``dashboard/onnx-light/backend-test-coverage.html`` and
+# ``dashboard/onnx-light-cpu/backend-end-coverage.html`` consume that file.
 
 on:
   schedule:
@@ -29,7 +30,7 @@ jobs:
   record:
     if: github.event_name == 'schedule' || github.actor == github.repository_owner || github.actor == 'github-actions[bot]'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - name: Checkout xadupre.github.io
         uses: actions/checkout@v6
@@ -54,6 +55,15 @@ jobs:
           repository: xadupre/onnx-light
           path: onnx-light
 
+      - name: Checkout onnx-light-cpu
+        uses: actions/checkout@v6
+        with:
+          repository: xadupre/onnx-light-cpu
+          path: onnx-light-cpu
+
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
       - name: Detect CPU cores
         run: |
           # Expose the number of available CPU cores as
@@ -63,11 +73,42 @@ jobs:
           echo "Detected ${cores} CPU cores."
           echo "CMAKE_BUILD_PARALLEL_LEVEL=${cores}" >> "$GITHUB_ENV"
 
-      - name: Install onnx, onnxruntime and onnx-light
+      - name: Build and install onnx-light from source
+        env:
+          SCCACHE_GHA_ENABLED: "true"
         run: |
           python -m pip install --upgrade pip
           pip install onnx onnxruntime numpy scikit-build-core nanobind
-          pip install -e ./onnx-light -v
+          cmake -S ./onnx-light -B ./onnx-light/build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=./onnx-light/install \
+            -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+          cmake --build ./onnx-light/build --config Release --parallel
+          cmake --install ./onnx-light/build --config Release
+          pip install ./onnx-light
+          onnx_light_install="$(cd ./onnx-light/install && pwd)"
+          echo "CMAKE_PREFIX_PATH=${onnx_light_install}${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}" >> "$GITHUB_ENV"
+          onnx_light_lib="$(find "${onnx_light_install}" -name 'liblib_onnx_core.so' | head -1)"
+          if [ -z "${onnx_light_lib}" ]; then
+            echo "liblib_onnx_core.so not found under ${onnx_light_install}" >&2
+            exit 1
+          fi
+          onnx_light_libdir="$(dirname "${onnx_light_lib}")"
+          echo "LD_LIBRARY_PATH=${onnx_light_libdir}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" >> "$GITHUB_ENV"
+
+      - name: Build and install onnx-light-cpu
+        working-directory: onnx-light-cpu
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+        run: |
+          pip install \
+            -C build-dir=build \
+            -C cmake.build-type=Release \
+            -C cmake.define.ONNX_LIGHT_CPU_WITH_ONNX_LIGHT=ON \
+            -C cmake.define.CMAKE_C_COMPILER_LAUNCHER=sccache \
+            -C cmake.define.CMAKE_CXX_COMPILER_LAUNCHER=sccache \
+            -e . -v
 
       - name: pip freeze
         run: pip freeze

--- a/dashboard/onnx-light-cpu/backend-end-coverage.html
+++ b/dashboard/onnx-light-cpu/backend-end-coverage.html
@@ -85,13 +85,12 @@ td.slower, td.failed { color: #f85149; }
   <div><a href="../../index.html">&larr; back to home</a></div>
   <h1>onnx-light-cpu &mdash; backend coverage</h1>
   <p class="intro">
-    This page runs the benchmark-sized ONNX backend tests through
+    This page runs every ONNX backend node and model test through
     <code>onnx-light</code> after
     <code>onnx_light_cpu.register_kernels()</code> installs the optimized
     <a href="https://github.com/xadupre/onnx-light-cpu">onnx-light-cpu</a>
-    kernels. Processing times are compared with <code>onnxruntime</code>;
-    speedup is <code>onnxruntime / onnx-light-cpu</code>, so values above one
-    mean the CPU kernels are faster.
+    kernels. A test succeeds only when its outputs match the expected values
+    and at least one <code>onnx-light-cpu</code> kernel ran.
   </p>
 </header>
 <main>
@@ -102,7 +101,7 @@ td.slower, td.failed { color: #f85149; }
   </section>
   <section id="resultsPanel" class="panel" hidden>
     <div class="controls">
-      <input id="search" type="search" placeholder="Filter tests or operators&hellip;" />
+      <input id="search" type="search" placeholder="Filter tests or tags&hellip;" />
       <label for="statusFilter">show:
         <select id="statusFilter">
           <option value="">all tests</option>
@@ -117,11 +116,8 @@ td.slower, td.failed { color: #f85149; }
         <thead>
           <tr>
             <th data-key="name">test</th>
-            <th data-key="operator">operator</th>
-            <th data-key="input_type">input type</th>
-            <th data-key="onnxruntime_avg_ms" class="number">onnxruntime avg</th>
-            <th data-key="onnx_light_cpu_avg_ms" class="number">onnx-light-cpu avg</th>
-            <th data-key="speedup_cpu" class="number">speedup</th>
+            <th data-key="tag">tag</th>
+            <th data-key="onnx_light_cpu_elapsed_s" class="number">elapsed (s)</th>
             <th data-key="status">status</th>
           </tr>
         </thead>
@@ -131,7 +127,7 @@ td.slower, td.failed { color: #f85149; }
   </section>
 </main>
 <script>
-const JSON_URL = "../../cache_data/onnx-light/benchmark.json";
+const JSON_URL = "../../cache_data/onnx-light/backend_test_coverage.json";
 const state = {
   rows: [],
   query: "",
@@ -146,7 +142,7 @@ function number(value, digits) {
     : "\u2014";
 }
 
-function addCard(container, label, value) {
+function addCard(container, label, value, suffix) {
   const card = document.createElement("div");
   card.className = "card";
   const cardLabel = document.createElement("div");
@@ -154,24 +150,28 @@ function addCard(container, label, value) {
   cardLabel.textContent = label;
   const cardValue = document.createElement("div");
   cardValue.className = "card-value";
-  cardValue.textContent = number(value, 2) + "\u00d7";
+  cardValue.textContent = String(value) + (suffix || "");
   card.append(cardLabel, cardValue);
   container.appendChild(card);
 }
 
 function renderSummary(payload) {
-  const summary = payload.summary || {};
+  const totals = (payload.totals || {}).onnx_light_cpu || {};
+  const passed = totals.pass || 0;
+  const failed = totals.fail || 0;
+  const total = passed + failed;
   document.getElementById("meta").textContent =
     "Snapshot recorded on " + (payload.date || "unknown date") + ".";
   const cards = document.getElementById("summary");
-  addCard(cards, "average speedup", summary.avg_speedup_cpu);
-  addCard(cards, "weighted average speedup", summary.avg_speedup_weighted_cpu);
-  addCard(cards, "sum latency speedup", summary.speedup_sum_latency_cpu);
+  addCard(cards, "tests", total);
+  addCard(cards, "passed", passed);
+  addCard(cards, "failed", failed);
+  addCard(cards, "pass ratio", total ? (100 * passed / total).toFixed(1) : "0.0", "%");
   document.getElementById("summaryPanel").hidden = false;
 }
 
 function rowStatus(row) {
-  if (row.onnx_light_cpu_success) return "succeeded";
+  if (row.onnx_light_cpu) return "succeeded";
   if ((row.onnx_light_cpu_error || "").startsWith("no onnx-light-cpu kernel ran"))
     return "no kernel";
   return row.onnx_light_cpu_error || "failed";
@@ -186,9 +186,9 @@ function valueForSort(row, key) {
 function renderRows() {
   const query = state.query.toLowerCase();
   const visible = state.rows.filter(row => {
-    if (state.statusFilter === "failing" && row.onnx_light_cpu_success) return false;
-    if (state.statusFilter === "succeeding" && !row.onnx_light_cpu_success) return false;
-    const text = [row.name, row.operator, row.input_type, rowStatus(row)]
+    if (state.statusFilter === "failing" && row.onnx_light_cpu) return false;
+    if (state.statusFilter === "succeeding" && !row.onnx_light_cpu) return false;
+    const text = [row.name, row.tag, rowStatus(row)]
       .filter(Boolean).join(" ").toLowerCase();
     return text.includes(query);
   });
@@ -204,24 +204,17 @@ function renderRows() {
   body.textContent = "";
   for (const row of visible) {
     const tr = document.createElement("tr");
-    const hasSpeedup =
-      typeof row.speedup_cpu === "number" && Number.isFinite(row.speedup_cpu);
     const values = [
       row.name || "",
-      row.operator || "",
-      row.input_type || "",
-      number(row.onnxruntime_avg_ms, 4),
-      number(row.onnx_light_cpu_avg_ms, 4),
-      number(row.speedup_cpu, 2) + (hasSpeedup ? "\u00d7" : ""),
+      row.tag || "",
+      number(row.onnx_light_cpu_elapsed_s, 6),
       rowStatus(row),
     ];
     values.forEach((value, index) => {
       const td = document.createElement("td");
       td.textContent = value;
-      if (index >= 3 && index <= 5) td.classList.add("number");
-      if (index === 5 && hasSpeedup)
-        td.classList.add(row.speedup_cpu >= 1 ? "faster" : "slower");
-      if (index === 6 && !row.onnx_light_cpu_success) td.classList.add("failed");
+      if (index === 2) td.classList.add("number");
+      if (index === 3 && !row.onnx_light_cpu) td.classList.add("failed");
       tr.appendChild(td);
     });
     body.appendChild(tr);
@@ -264,10 +257,10 @@ fetch(JSON_URL, { cache: "no-store" })
   })
   .catch(error => {
     document.getElementById("message").textContent =
-      "Failed to load benchmark data: " + error.message;
+      "Failed to load backend coverage data: " + error.message;
   });
 </script>
-<footer class="data-updated" data-source="../../cache_data/onnx-light/benchmark.json" style="margin-top:1.5em;font-size:0.75em;color:#8b949e;text-align:center;display:none;"></footer>
+<footer class="data-updated" data-source="../../cache_data/onnx-light/backend_test_coverage.json" style="margin-top:1.5em;font-size:0.75em;color:#8b949e;text-align:center;display:none;"></footer>
 <script src="../../assets/last-updated.js"></script>
 </body>
 </html>

--- a/scripts/record_onnx_backend_test_coverage.py
+++ b/scripts/record_onnx_backend_test_coverage.py
@@ -9,7 +9,8 @@ against:
 * ``onnxruntime`` (CPU execution provider),
 * the ONNX Python reference implementation (``onnx.reference``) and
 * the ``onnx-light`` reference implementation backed by the C++
-  ``KernelDispatchTable`` (``onnx_light.onnx.reference``),
+  ``KernelDispatchTable`` (``onnx_light.onnx.reference``), and
+  * ``onnx-light`` with the optimized ``onnx-light-cpu`` kernels registered,
 
 and records whether the produced outputs match the expected ones. By
 default both the ``node`` (single-operator) and ``model`` (multi-node,
@@ -37,7 +38,12 @@ import time
 import traceback
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-BACKENDS: Tuple[str, ...] = ("onnxruntime", "reference", "onnx_light")
+BACKENDS: Tuple[str, ...] = (
+    "onnxruntime",
+    "reference",
+    "onnx_light",
+    "onnx_light_cpu",
+)
 
 # Package whose version is recorded alongside the ``last_pass`` date for
 # each backend. ``onnxruntime`` runs the model with the ``onnxruntime``
@@ -47,6 +53,7 @@ BACKEND_PACKAGE: Dict[str, str] = {
     "onnxruntime": "onnxruntime",
     "reference": "onnx",
     "onnx_light": "onnx_light",
+    "onnx_light_cpu": "onnx_light_cpu",
 }
 
 # Default numerical tolerances when comparing produced outputs with the
@@ -109,7 +116,7 @@ def _format_iso(value: dt.datetime) -> str:
 def collect_versions() -> Dict[str, str]:
     """Return the versions of the relevant packages, if importable."""
     versions: Dict[str, str] = {}
-    for name in ("onnx", "onnxruntime", "onnx_light", "numpy"):
+    for name in ("onnx", "onnxruntime", "onnx_light", "onnx_light_cpu", "numpy"):
         try:
             module = __import__(name)
         except Exception:  # noqa: BLE001 - best effort, optional packages
@@ -620,10 +627,39 @@ def _run_with_onnx_light(model) -> Callable[[List[Any]], List[Any]]:
     return _run
 
 
+_CPU_KERNELS_REGISTERED = False
+
+
+def _run_with_onnx_light_cpu(model) -> Callable[[List[Any]], List[Any]]:
+    """Run with onnx-light-cpu and require an optimized kernel to be used."""
+    global _CPU_KERNELS_REGISTERED
+
+    from onnx_light_cpu import (
+        clear_used_kernel_names,
+        register_kernels,
+        used_kernel_names,
+    )
+
+    if not _CPU_KERNELS_REGISTERED:
+        register_kernels()
+        _CPU_KERNELS_REGISTERED = True
+    run = _run_with_onnx_light(model)
+
+    def _run(inputs: List[Any]) -> List[Any]:
+        clear_used_kernel_names()
+        outputs = run(inputs)
+        if not used_kernel_names():
+            raise RuntimeError("no onnx-light-cpu kernel ran")
+        return outputs
+
+    return _run
+
+
 _BACKEND_FACTORIES: Dict[str, Callable[[Any], Callable[[List[Any]], List[Any]]]] = {
     "onnxruntime": _run_with_onnxruntime,
     "reference": _run_with_reference,
     "onnx_light": _run_with_onnx_light,
+    "onnx_light_cpu": _run_with_onnx_light_cpu,
 }
 
 
@@ -820,10 +856,11 @@ def build_payload(
     version_map = versions()
     previous_rows = _index_previous_rows(previous or {})
 
-    rows: List[Dict[str, Any]] = []
+    entries: List[Dict[str, Any]] = []
     totals: Dict[str, Dict[str, int]] = {
         backend: {"pass": 0, "fail": 0} for backend in BACKENDS
     }
+    baseline_backends = tuple(b for b in BACKENDS if b != "onnx_light_cpu")
     for idx, test in enumerate(tests):
         name = test["name"]
         model = test["model"]
@@ -833,7 +870,7 @@ def build_payload(
             graph = build_graph(model)
         except Exception:  # noqa: BLE001 - graph is a best-effort annotation
             graph = None
-        for backend in BACKENDS:
+        for backend in baseline_backends:
             try:
                 info = run(model, data_sets, backend, rtol=rtol, atol=atol)
             except Exception as exc:  # noqa: BLE001
@@ -852,19 +889,59 @@ def build_payload(
             results[backend] = info
             bucket = "pass" if info.get("success") else "fail"
             totals[backend][bucket] += 1
+        entries.append(
+            {
+                "test": test,
+                "results": results,
+                "graph": graph,
+            }
+        )
+        if (idx + 1) % 50 == 0:
+            _log(f"Ran {idx + 1}/{len(tests)} tests on baseline backends.")
+
+    # Kernel registration is process-wide and irreversible. Run every
+    # unmodified onnx-light baseline first, then install onnx-light-cpu once
+    # and execute its complete pass so the baseline remains trustworthy.
+    for idx, entry in enumerate(entries):
+        test = entry["test"]
+        try:
+            info = run(
+                test["model"],
+                test["data_sets"],
+                "onnx_light_cpu",
+                rtol=rtol,
+                atol=atol,
+            )
+        except Exception as exc:  # noqa: BLE001
+            _log(
+                f"Unhandled error for {test['name']} on onnx_light_cpu: {exc}\n"
+                f"{traceback.format_exc()}"
+            )
+            info = {
+                "success": False,
+                "error": _stringify_error(exc),
+                "error_step": "run",
+            }
+        entry["results"]["onnx_light_cpu"] = info
+        bucket = "pass" if info.get("success") else "fail"
+        totals["onnx_light_cpu"][bucket] += 1
+        if (idx + 1) % 50 == 0:
+            _log(f"Ran {idx + 1}/{len(tests)} tests on onnx-light-cpu.")
+
+    rows: List[Dict[str, Any]] = []
+    for entry in entries:
+        test = entry["test"]
         rows.append(
             _row_from_results(
-                name,
-                results,
-                previous=previous_rows.get(name),
+                test["name"],
+                entry["results"],
+                previous=previous_rows.get(test["name"]),
                 versions=version_map,
                 now_iso=now_iso,
                 tag=str(test.get("tag", "") or ""),
-                graph=graph,
+                graph=entry["graph"],
             )
         )
-        if (idx + 1) % 50 == 0:
-            _log(f"Ran {idx + 1}/{len(tests)} tests.")
 
     slowest = sorted(
         (r for r in rows if r.get("elapsed_s")),

--- a/scripts/tests/test_onnx_light_cpu_backend_end_coverage_dashboard.py
+++ b/scripts/tests/test_onnx_light_cpu_backend_end_coverage_dashboard.py
@@ -12,7 +12,7 @@ PAGE = os.path.join(
 )
 INDEX = os.path.join(REPO_ROOT, "index.html")
 WORKFLOW = os.path.join(
-    REPO_ROOT, ".github", "workflows", "record_onnx_light_benchmark.yml"
+    REPO_ROOT, ".github", "workflows", "record_onnx_backend_test_coverage.yml"
 )
 
 
@@ -22,18 +22,20 @@ def _read(path: str) -> str:
 
 
 class TestOnnxLightCpuBackendEndCoverageDashboard(unittest.TestCase):
-    def test_page_uses_onnx_light_benchmark_data(self):
+    def test_page_uses_complete_backend_coverage_data(self):
         text = _read(PAGE)
         self.assertIn(
-            'const JSON_URL = "../../cache_data/onnx-light/benchmark.json";', text
+            'const JSON_URL = '
+            '"../../cache_data/onnx-light/backend_test_coverage.json";',
+            text,
         )
         for field in (
-            "onnx_light_cpu_avg_ms",
-            "onnx_light_cpu_success",
-            "speedup_cpu",
-            "avg_speedup_cpu",
-            "avg_speedup_weighted_cpu",
-            "speedup_sum_latency_cpu",
+            "onnx_light_cpu_elapsed_s",
+            "payload.totals",
+            '"tests"',
+            '"passed"',
+            '"failed"',
+            '"pass ratio"',
         ):
             self.assertIn(field, text)
 
@@ -57,7 +59,8 @@ class TestOnnxLightCpuBackendEndCoverageDashboard(unittest.TestCase):
     def test_page_has_last_updated_footer(self):
         text = _read(PAGE)
         self.assertIn(
-            'data-source="../../cache_data/onnx-light/benchmark.json"', text
+            'data-source="../../cache_data/onnx-light/backend_test_coverage.json"',
+            text,
         )
         self.assertIn('<script src="../../assets/last-updated.js">', text)
 
@@ -68,9 +71,10 @@ class TestOnnxLightCpuBackendEndCoverageDashboard(unittest.TestCase):
 
     def test_recording_workflow_links_page_and_data(self):
         text = _read(WORKFLOW)
-        self.assertIn("name: DATA onnx-light and onnx-light-cpu benchmark", text)
+        self.assertIn("name: DATA onnx-light backend test coverage", text)
         self.assertIn("dashboard/onnx-light-cpu/backend-end-coverage.html", text)
-        self.assertIn("cache_data/onnx-light/benchmark.json", text)
+        self.assertIn("cache_data/onnx-light/backend_test_coverage.json", text)
+        self.assertIn("ONNX_LIGHT_CPU_WITH_ONNX_LIGHT=ON", text)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_record_onnx_backend_test_coverage.py
+++ b/scripts/tests/test_record_onnx_backend_test_coverage.py
@@ -211,6 +211,7 @@ class TestRecordOnnxBackendTestCoverage(unittest.TestCase):
             ("model_a", "onnxruntime"): ok,
             ("model_a", "reference"): ok,
             ("model_a", "onnx_light"): ok,
+            ("model_a", "onnx_light_cpu"): ok,
             ("model_b", "onnxruntime"): ok,
             ("model_b", "reference"): {
                 "success": False,
@@ -218,6 +219,7 @@ class TestRecordOnnxBackendTestCoverage(unittest.TestCase):
                 "error_step": "run",
             },
             ("model_b", "onnx_light"): ok,
+            ("model_b", "onnx_light_cpu"): ok,
             ("model_c", "onnxruntime"): {
                 "success": False,
                 "error": "kernel missing",
@@ -227,6 +229,11 @@ class TestRecordOnnxBackendTestCoverage(unittest.TestCase):
             ("model_c", "onnx_light"): {
                 "success": False,
                 "error": "kernel missing in onnx-light",
+                "error_step": "run",
+            },
+            ("model_c", "onnx_light_cpu"): {
+                "success": False,
+                "error": "no onnx-light-cpu kernel ran",
                 "error_step": "run",
             },
         }
@@ -249,6 +256,7 @@ class TestRecordOnnxBackendTestCoverage(unittest.TestCase):
                 "onnxruntime": {"pass": 2, "fail": 1},
                 "reference": {"pass": 2, "fail": 1},
                 "onnx_light": {"pass": 2, "fail": 1},
+                "onnx_light_cpu": {"pass": 2, "fail": 1},
             },
         )
         names = [row["name"] for row in payload["tests"]]
@@ -291,7 +299,38 @@ class TestRecordOnnxBackendTestCoverage(unittest.TestCase):
                 "onnxruntime": {"pass": 2, "fail": 0},
                 "reference": {"pass": 2, "fail": 0},
                 "onnx_light": {"pass": 2, "fail": 0},
+                "onnx_light_cpu": {"pass": 2, "fail": 0},
             },
+        )
+
+    def test_build_payload_defers_cpu_until_after_all_baselines(self):
+        tests = [
+            {"name": "test_a", "model": "model_a", "data_sets": []},
+            {"name": "test_b", "model": "model_b", "data_sets": []},
+        ]
+        calls = []
+
+        def fake_run(model, data_sets, backend, rtol, atol):
+            calls.append((model, backend))
+            return {"success": True, "error": "", "error_step": ""}
+
+        rbc.build_payload(
+            discover=lambda kind: tests,
+            run=fake_run,
+            versions=lambda: {},
+        )
+
+        first_cpu = next(i for i, (_, backend) in enumerate(calls)
+                         if backend == "onnx_light_cpu")
+        self.assertTrue(
+            all(backend != "onnx_light_cpu" for _, backend in calls[:first_cpu])
+        )
+        self.assertEqual(
+            calls[first_cpu:],
+            [
+                ("model_a", "onnx_light_cpu"),
+                ("model_b", "onnx_light_cpu"),
+            ],
         )
 
     def test_build_payload_captures_unhandled_runner_exceptions(self):
@@ -310,6 +349,7 @@ class TestRecordOnnxBackendTestCoverage(unittest.TestCase):
         self.assertFalse(row["onnxruntime"])
         self.assertFalse(row["reference"])
         self.assertFalse(row["onnx_light"])
+        self.assertFalse(row["onnx_light_cpu"])
         self.assertEqual(row["onnxruntime_error"], "unexpected")
         self.assertEqual(row["reference_error_step"], "run")
         self.assertEqual(row["onnx_light_error_step"], "run")
@@ -319,6 +359,7 @@ class TestRecordOnnxBackendTestCoverage(unittest.TestCase):
                 "onnxruntime": {"pass": 0, "fail": 1},
                 "reference": {"pass": 0, "fail": 1},
                 "onnx_light": {"pass": 0, "fail": 1},
+                "onnx_light_cpu": {"pass": 0, "fail": 1},
             },
         )
 
@@ -398,6 +439,13 @@ class TestRecordOnnxBackendTestCoverage(unittest.TestCase):
         self.assertIn("onnx_light", rbc.BACKENDS)
         self.assertIn("onnx_light", rbc._BACKEND_FACTORIES)
         self.assertEqual(rbc.BACKEND_PACKAGE["onnx_light"], "onnx_light")
+
+    def test_backends_include_onnx_light_cpu(self):
+        self.assertIn("onnx_light_cpu", rbc.BACKENDS)
+        self.assertIn("onnx_light_cpu", rbc._BACKEND_FACTORIES)
+        self.assertEqual(
+            rbc.BACKEND_PACKAGE["onnx_light_cpu"], "onnx_light_cpu"
+        )
 
     def test_run_with_onnx_light_uses_onnx_light_reference_evaluator(self):
         """``_run_with_onnx_light`` builds and drives the onnx-light evaluator.


### PR DESCRIPTION
The CPU backend coverage dashboard was incorrectly reading the benchmark-only snapshot, reducing the displayed corpus to 231 cases.\n\n- point the dashboard at the complete backend test coverage snapshot (currently 2,138 node/model cases)\n- record onnx-light-cpu results for that full corpus\n- defer global CPU kernel registration until every baseline backend test has completed\n- require at least one optimized CPU kernel to run for a CPU test to pass\n- build onnx-light and onnx-light-cpu with integration enabled in the coverage workflow\n- show test totals, passes, failures, pass ratio, and elapsed time\n\nValidated with 59 focused tests.