### PR TITLE
Fix examples benchmark input type column

### DIFF
--- a/dashboard/onnx-light-cpu/examples-benchmark.html
+++ b/dashboard/onnx-light-cpu/examples-benchmark.html
@@ -125,7 +125,6 @@ table.benchmark th, table.benchmark td {
 }
 table.benchmark th { color: #8b949e; font-weight: normal; }
 table.benchmark th:first-child, table.benchmark td:first-child { text-align: left; }
-table.benchmark th:nth-child(2), table.benchmark td:nth-child(2) { text-align: left; }
 table.benchmark td.faster { color: #3fb950; font-weight: bold; }
 table.benchmark td.slower { color: #f85149; font-weight: bold; }
 table.benchmark td.neutral { color: #bc8cff; font-weight: bold; }
@@ -310,24 +309,18 @@ function classifyExample(example) {
   return cats;
 }
 
-function inputSignature(row) {
-  const value = (row.inputs !== undefined && row.inputs !== null)
-    ? row.inputs
-    : (row.input_type !== undefined && row.input_type !== null)
-      ? row.input_type
-      : row.size;
-  return (value === undefined || value === null) ? "" : String(value);
-}
-
 // Element type of the first input, e.g. "float32" for "float32[16x16],
 // float32[16x16]". This is the convention used by the onnx-light benchmark
 // dashboard, so both pages report the same input type for the same model.
 // Older payloads store the whole signature in `input_type`; parsing the first
 // token handles both layouts.
 function firstInputType(row) {
-  const raw = (row.input_type !== undefined && row.input_type !== null)
-    ? String(row.input_type)
-    : inputSignature(row);
+  const value = (row.input_type !== undefined && row.input_type !== null)
+    ? row.input_type
+    : (row.inputs !== undefined && row.inputs !== null)
+      ? row.inputs
+      : row.size;
+  const raw = (value === undefined || value === null) ? "" : String(value);
   const first = raw.split(",")[0].split("[")[0].trim();
   return /^[A-Za-z_][A-Za-z0-9_]*$/.test(first) ? first : "";
 }
@@ -415,9 +408,6 @@ function renderExample(example, cats) {
 
   const thead = document.createElement("thead");
   const htr = document.createElement("tr");
-  const sizeTh = document.createElement("th");
-  sizeTh.textContent = "inputs";
-  htr.appendChild(sizeTh);
   const typeTh = document.createElement("th");
   typeTh.textContent = "input type";
   htr.appendChild(typeTh);
@@ -435,11 +425,6 @@ function renderExample(example, cats) {
   const tbody = document.createElement("tbody");
   (example.rows || []).forEach(row => {
     const tr = document.createElement("tr");
-    const signature = inputSignature(row);
-    const sizeTd = document.createElement("td");
-    sizeTd.textContent = signature || "—";
-    tr.appendChild(sizeTd);
-    /* Input type (first input), same convention as the onnx-light benchmark. */
     const typeTd = document.createElement("td");
     const inputType = firstInputType(row);
     if (inputType) {

--- a/scripts/tests/test_examples_benchmark_dashboard.py
+++ b/scripts/tests/test_examples_benchmark_dashboard.py
@@ -59,16 +59,13 @@ class TestExamplesBenchmarkDashboard(unittest.TestCase):
     def test_input_type_column_matches_the_onnx_light_benchmark(self):
         text = _read(PAGE)
         # The "input type" column holds the element type of the first input
-        # (e.g. "float32"), exactly like dashboard/onnx-light/benchmark.html;
-        # the full dtype[shape] signature goes to the "inputs" column.
+        # (e.g. "float32"), exactly like dashboard/onnx-light/benchmark.html.
         self.assertIn("function firstInputType(row)", text)
-        self.assertIn("function inputSignature(row)", text)
-        self.assertIn('sizeTh.textContent = "inputs";', text)
         self.assertIn('typeTh.textContent = "input type";', text)
-        self.assertLess(
-            text.index('sizeTh.textContent = "inputs";'),
-            text.index('typeTh.textContent = "input type";'),
-        )
+        self.assertNotIn('sizeTh.textContent = "inputs";', text)
+        self.assertIn("? row.input_type", text)
+        self.assertIn("? row.inputs", text)
+        self.assertIn('raw.split(",")[0].split("[")[0].trim()', text)
         self.assertIn('code.textContent = inputType;', text)
 
     def test_panels_are_sorted_by_operator(self):


### PR DESCRIPTION
## Summary
- replace the detailed table's `inputs` column with `input type`
- display the element type of the first input while retaining compatibility with older payloads
- update the dashboard regression test

## Tests
- `python scripts/tests/test_examples_benchmark_dashboard.py`
- `python scripts/tests/test_record_onnx_light_cpu_benchmark.py`
