### PR TITLE
Fix benchmark summary input types

### DIFF
--- a/dashboard/onnx-light-cpu/examples-benchmark.html
+++ b/dashboard/onnx-light-cpu/examples-benchmark.html
@@ -330,12 +330,14 @@ function renderExample(example, cats) {
   panel.className = "panel operator-panel";
 
   const summary = example.summary || {};
+  const inputTypes = [...new Set(
+    (example.rows || []).map(firstInputType).filter(Boolean)
+  )].join(", ");
   const summaryRow = document.createElement("summary");
   summaryRow.className = "operator-summary";
   const summaryValues = [
     ["operator", example.op || example.title || example.name, "operator-name"],
-    ["inputs", String(summary.inputs || summary.input_types ||
-      (example.rows || []).length), ""],
+    ["input types", inputTypes || "—", ""],
     ["average speed-up", fmtSpeedup(summary.avg_speedup_cpu),
       speedupClass(summary.avg_speedup_cpu)],
     ["best speed-up", fmtSpeedup(summary.max_speedup_cpu),

--- a/dashboard/onnx-light-cpu/examples-benchmark.html
+++ b/dashboard/onnx-light-cpu/examples-benchmark.html
@@ -309,19 +309,21 @@ function classifyExample(example) {
   return cats;
 }
 
-// Element type of the first input, e.g. "float32" for "float32[16x16],
-// float32[16x16]". This is the convention used by the onnx-light benchmark
-// dashboard, so both pages report the same input type for the same model.
-// Older payloads store the whole signature in `input_type`; parsing the first
-// token handles both layouts.
-function firstInputType(row) {
-  const value = (row.input_type !== undefined && row.input_type !== null)
-    ? row.input_type
-    : (row.inputs !== undefined && row.inputs !== null)
-      ? row.inputs
+function firstInputTensor(row) {
+  const value = (row.inputs !== undefined && row.inputs !== null)
+    ? row.inputs
+    : (row.input_type !== undefined && row.input_type !== null)
+      ? row.input_type
       : row.size;
   const raw = (value === undefined || value === null) ? "" : String(value);
-  const first = raw.split(",")[0].split("[")[0].trim();
+  return raw.split(",")[0].trim();
+}
+
+// Element type of the first input, e.g. "float32" for "float32[16x16],
+// float32[16x16]". Older payloads store the whole signature in `input_type`;
+// firstInputTensor handles both layouts.
+function firstInputType(row) {
+  const first = firstInputTensor(row).split("[")[0].trim();
   return /^[A-Za-z_][A-Za-z0-9_]*$/.test(first) ? first : "";
 }
 
@@ -411,7 +413,7 @@ function renderExample(example, cats) {
   const thead = document.createElement("thead");
   const htr = document.createElement("tr");
   const typeTh = document.createElement("th");
-  typeTh.textContent = "input type";
+  typeTh.textContent = "first input tensor";
   htr.appendChild(typeTh);
   backends.forEach(b => {
     const th = document.createElement("th");
@@ -428,10 +430,10 @@ function renderExample(example, cats) {
   (example.rows || []).forEach(row => {
     const tr = document.createElement("tr");
     const typeTd = document.createElement("td");
-    const inputType = firstInputType(row);
-    if (inputType) {
+    const inputTensor = firstInputTensor(row);
+    if (inputTensor) {
       const code = document.createElement("code");
-      code.textContent = inputType;
+      code.textContent = inputTensor;
       typeTd.appendChild(code);
     } else {
       typeTd.textContent = "—";

--- a/scripts/tests/test_examples_benchmark_dashboard.py
+++ b/scripts/tests/test_examples_benchmark_dashboard.py
@@ -8,12 +8,16 @@ import unittest
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 REPO_ROOT = os.path.normpath(os.path.join(HERE, "..", ".."))
-PAGE = os.path.join(REPO_ROOT, "dashboard", "onnx-light-cpu", "examples-benchmark.html")
+PAGE = os.path.join(
+    REPO_ROOT, "dashboard", "onnx-light-cpu", "examples-benchmark.html"
+)
 INDEX = os.path.join(REPO_ROOT, "index.html")
 WORKFLOW = os.path.join(
     REPO_ROOT, ".github", "workflows", "record_onnx_light_cpu_examples_benchmark.yml"
 )
-SCRIPT = os.path.join(REPO_ROOT, "scripts", "record_onnx_light_cpu_benchmark.py")
+SCRIPT = os.path.join(
+    REPO_ROOT, "scripts", "record_onnx_light_cpu_benchmark.py"
+)
 sys.path.insert(0, os.path.dirname(SCRIPT))
 
 
@@ -70,7 +74,7 @@ class TestExamplesBenchmarkDashboard(unittest.TestCase):
         self.assertIn("? row.input_type", text)
         self.assertIn("? row.inputs", text)
         self.assertIn('raw.split(",")[0].split("[")[0].trim()', text)
-        self.assertIn("code.textContent = inputType;", text)
+        self.assertIn('code.textContent = inputType;', text)
 
     def test_panels_are_sorted_by_operator(self):
         text = _read(PAGE)
@@ -104,7 +108,9 @@ class TestExamplesBenchmarkDashboard(unittest.TestCase):
         # SMALL/MID/BIG derive from the speed-up on the first/last/middle sizes.
         self.assertIn("cats.small = first !== null && first > 1;", text)
         self.assertIn("cats.big = last !== null && last > 1;", text)
-        self.assertIn("cats.mid = minIdx > 0 && minIdx < rows.length - 1;", text)
+        self.assertIn(
+            "cats.mid = minIdx > 0 && minIdx < rows.length - 1;", text
+        )
 
     def test_page_has_category_checkbox_column(self):
         text = _read(PAGE)
@@ -130,7 +136,9 @@ class TestExamplesBenchmarkDashboard(unittest.TestCase):
 class TestIndexWiring(unittest.TestCase):
     def test_index_links_dashboard(self):
         text = _read(INDEX)
-        self.assertIn('href="dashboard/onnx-light-cpu/examples-benchmark.html"', text)
+        self.assertIn(
+            'href="dashboard/onnx-light-cpu/examples-benchmark.html"', text
+        )
         # The doc-link label / word must match (checked generically elsewhere).
         self.assertIn('data-word="BENCH"', text)
 
@@ -150,8 +158,12 @@ class TestWorkflow(unittest.TestCase):
         self.assertIn("repository: xadupre/onnx-light", text)
         self.assertIn("repository: xadupre/onnx-light-cpu", text)
         self.assertIn("ONNX_LIGHT_CPU_WITH_ONNX_LIGHT=ON", text)
-        self.assertIn("python -u scripts/record_onnx_light_cpu_benchmark.py", text)
-        self.assertIn("cache_data/onnx-light-cpu/examples_benchmark.json", text)
+        self.assertIn(
+            "python -u scripts/record_onnx_light_cpu_benchmark.py", text
+        )
+        self.assertIn(
+            "cache_data/onnx-light-cpu/examples_benchmark.json", text
+        )
 
 
 class TestScriptCLI(unittest.TestCase):

--- a/scripts/tests/test_examples_benchmark_dashboard.py
+++ b/scripts/tests/test_examples_benchmark_dashboard.py
@@ -64,17 +64,19 @@ class TestExamplesBenchmarkDashboard(unittest.TestCase):
         self.assertIn("(example.rows || []).map(firstInputType).filter(Boolean)", text)
         self.assertIn('["input types", inputTypes || "—", ""]', text)
 
-    def test_input_type_column_matches_the_onnx_light_benchmark(self):
+    def test_expanded_table_shows_the_first_input_tensor_shape(self):
         text = _read(PAGE)
-        # The "input type" column holds the element type of the first input
-        # (e.g. "float32"), exactly like dashboard/onnx-light/benchmark.html.
+        # The summary groups rows by first-input type, while the expanded table
+        # shows the first tensor's type and dimensions (e.g. "float32[16x16]").
+        self.assertIn("function firstInputTensor(row)", text)
         self.assertIn("function firstInputType(row)", text)
-        self.assertIn('typeTh.textContent = "input type";', text)
+        self.assertIn('typeTh.textContent = "first input tensor";', text)
         self.assertNotIn('sizeTh.textContent = "inputs";', text)
-        self.assertIn("? row.input_type", text)
         self.assertIn("? row.inputs", text)
-        self.assertIn('raw.split(",")[0].split("[")[0].trim()', text)
-        self.assertIn('code.textContent = inputType;', text)
+        self.assertIn("? row.input_type", text)
+        self.assertIn('return raw.split(",")[0].trim();', text)
+        self.assertIn('firstInputTensor(row).split("[")[0].trim()', text)
+        self.assertIn("code.textContent = inputTensor;", text)
 
     def test_panels_are_sorted_by_operator(self):
         text = _read(PAGE)

--- a/scripts/tests/test_examples_benchmark_dashboard.py
+++ b/scripts/tests/test_examples_benchmark_dashboard.py
@@ -8,16 +8,12 @@ import unittest
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 REPO_ROOT = os.path.normpath(os.path.join(HERE, "..", ".."))
-PAGE = os.path.join(
-    REPO_ROOT, "dashboard", "onnx-light-cpu", "examples-benchmark.html"
-)
+PAGE = os.path.join(REPO_ROOT, "dashboard", "onnx-light-cpu", "examples-benchmark.html")
 INDEX = os.path.join(REPO_ROOT, "index.html")
 WORKFLOW = os.path.join(
     REPO_ROOT, ".github", "workflows", "record_onnx_light_cpu_examples_benchmark.yml"
 )
-SCRIPT = os.path.join(
-    REPO_ROOT, "scripts", "record_onnx_light_cpu_benchmark.py"
-)
+SCRIPT = os.path.join(REPO_ROOT, "scripts", "record_onnx_light_cpu_benchmark.py")
 sys.path.insert(0, os.path.dirname(SCRIPT))
 
 
@@ -53,8 +49,16 @@ class TestExamplesBenchmarkDashboard(unittest.TestCase):
         self.assertIn('summaryRow.className = "operator-summary"', text)
         self.assertIn('details.className = "operator-details"', text)
         self.assertNotIn("panel.open = true", text)
-        for label in ("inputs", "average speed-up", "best speed-up", "worst speed-up"):
+        for label in (
+            "input types",
+            "average speed-up",
+            "best speed-up",
+            "worst speed-up",
+        ):
             self.assertIn(label, text)
+        self.assertNotIn('["inputs", String(summary.inputs', text)
+        self.assertIn("(example.rows || []).map(firstInputType).filter(Boolean)", text)
+        self.assertIn('["input types", inputTypes || "—", ""]', text)
 
     def test_input_type_column_matches_the_onnx_light_benchmark(self):
         text = _read(PAGE)
@@ -66,7 +70,7 @@ class TestExamplesBenchmarkDashboard(unittest.TestCase):
         self.assertIn("? row.input_type", text)
         self.assertIn("? row.inputs", text)
         self.assertIn('raw.split(",")[0].split("[")[0].trim()', text)
-        self.assertIn('code.textContent = inputType;', text)
+        self.assertIn("code.textContent = inputType;", text)
 
     def test_panels_are_sorted_by_operator(self):
         text = _read(PAGE)
@@ -100,9 +104,7 @@ class TestExamplesBenchmarkDashboard(unittest.TestCase):
         # SMALL/MID/BIG derive from the speed-up on the first/last/middle sizes.
         self.assertIn("cats.small = first !== null && first > 1;", text)
         self.assertIn("cats.big = last !== null && last > 1;", text)
-        self.assertIn(
-            "cats.mid = minIdx > 0 && minIdx < rows.length - 1;", text
-        )
+        self.assertIn("cats.mid = minIdx > 0 && minIdx < rows.length - 1;", text)
 
     def test_page_has_category_checkbox_column(self):
         text = _read(PAGE)
@@ -128,9 +130,7 @@ class TestExamplesBenchmarkDashboard(unittest.TestCase):
 class TestIndexWiring(unittest.TestCase):
     def test_index_links_dashboard(self):
         text = _read(INDEX)
-        self.assertIn(
-            'href="dashboard/onnx-light-cpu/examples-benchmark.html"', text
-        )
+        self.assertIn('href="dashboard/onnx-light-cpu/examples-benchmark.html"', text)
         # The doc-link label / word must match (checked generically elsewhere).
         self.assertIn('data-word="BENCH"', text)
 
@@ -150,12 +150,8 @@ class TestWorkflow(unittest.TestCase):
         self.assertIn("repository: xadupre/onnx-light", text)
         self.assertIn("repository: xadupre/onnx-light-cpu", text)
         self.assertIn("ONNX_LIGHT_CPU_WITH_ONNX_LIGHT=ON", text)
-        self.assertIn(
-            "python -u scripts/record_onnx_light_cpu_benchmark.py", text
-        )
-        self.assertIn(
-            "cache_data/onnx-light-cpu/examples_benchmark.json", text
-        )
+        self.assertIn("python -u scripts/record_onnx_light_cpu_benchmark.py", text)
+        self.assertIn("cache_data/onnx-light-cpu/examples_benchmark.json", text)
 
 
 class TestScriptCLI(unittest.TestCase):


### PR DESCRIPTION
The folded operator summary currently displays the numeric `summary.inputs` count under an `inputs` label, despite the detailed table already showing the actual input type.

This change:
- renames the visible summary field to `input types`;
- derives distinct input types from the benchmark rows with the existing `firstInputType` parser;
- adds regression assertions that reject the old numeric summary field.

Validation:
- `python scripts/tests/test_examples_benchmark_dashboard.py`
- `python scripts/tests/test_record_onnx_light_cpu_benchmark.py`
- `ruff check scripts/tests/test_examples_benchmark_dashboard.py`