### PR TITLE
Add GitHub Actions schedule to home page

### DIFF
--- a/assets/workflow-manifest.json
+++ b/assets/workflow-manifest.json
@@ -1,0 +1,229 @@
+[
+  {
+    "crons": [
+      "17 4 * * 1"
+    ],
+    "name": "DATA build durations",
+    "path": ".github/workflows/record_build_durations.yml"
+  },
+  {
+    "crons": [
+      "23 9 * * 1"
+    ],
+    "name": "DATA export model-ids to ONNX",
+    "path": ".github/workflows/record_yobx_model_validate.yml"
+  },
+  {
+    "crons": [
+      "21 7 * * 1"
+    ],
+    "name": "DATA mbext class coverage",
+    "path": ".github/workflows/record_mbext_class_coverage.yml"
+  },
+  {
+    "crons": [
+      "47 7 * * 1"
+    ],
+    "name": "DATA onnx backend node test coverage",
+    "path": ".github/workflows/record_onnx_backend_node_coverage.yml"
+  },
+  {
+    "crons": [
+      "17 6 * * 1"
+    ],
+    "name": "DATA onnx stats",
+    "path": ".github/workflows/record_onnx_stats.yml"
+  },
+  {
+    "crons": [
+      "13 8 * * 1"
+    ],
+    "name": "DATA onnx-light and onnx-light-cpu benchmark",
+    "path": ".github/workflows/record_onnx_light_benchmark.yml"
+  },
+  {
+    "crons": [
+      "29 7 * * 1"
+    ],
+    "name": "DATA onnx-light backend test coverage",
+    "path": ".github/workflows/record_onnx_backend_test_coverage.yml"
+  },
+  {
+    "crons": [
+      "17 7 * * 1"
+    ],
+    "name": "DATA onnx-light constant information coverage",
+    "path": ".github/workflows/record_onnx_constant_info_coverage.yml"
+  },
+  {
+    "crons": [
+      "53 7 * * 1"
+    ],
+    "name": "DATA onnx-light inplace metadata coverage",
+    "path": ".github/workflows/record_onnx_inplace_reuse_coverage.yml"
+  },
+  {
+    "crons": [
+      "23 8 * * 1"
+    ],
+    "name": "DATA onnx-light load/save timings",
+    "path": ".github/workflows/record_onnx_time.yml"
+  },
+  {
+    "crons": [
+      "57 7 * * 1"
+    ],
+    "name": "DATA onnx-light release-after metadata coverage",
+    "path": ".github/workflows/record_onnx_release_after_coverage.yml"
+  },
+  {
+    "crons": [
+      "41 7 * * 1"
+    ],
+    "name": "DATA onnx-light shape inference coverage",
+    "path": ".github/workflows/record_onnx_shape_inference_coverage.yml"
+  },
+  {
+    "crons": [
+      "17 8 * * 1"
+    ],
+    "name": "DATA onnx-light shape-tag metadata coverage",
+    "path": ".github/workflows/record_onnx_shape_tag_coverage.yml"
+  },
+  {
+    "crons": [
+      "17 5 * * 1"
+    ],
+    "name": "DATA onnx-light size and ops",
+    "path": ".github/workflows/record_size_onnx_light.yml"
+  },
+  {
+    "crons": [
+      "17 6 * * 1"
+    ],
+    "name": "DATA onnx-light vs emx-onnx-cgen comparison",
+    "path": ".github/workflows/record_cgen_comparison.yml"
+  },
+  {
+    "crons": [
+      "41 8 * * 1"
+    ],
+    "name": "DATA onnx-light-cpu benchmark",
+    "path": ".github/workflows/record_onnx_light_cpu_examples_benchmark.yml"
+  },
+  {
+    "crons": [
+      "23 5 * * 1"
+    ],
+    "name": "DATA onnx-light-cpu build durations",
+    "path": ".github/workflows/record_build_durations_onnx_light_cpu.yml"
+  },
+  {
+    "crons": [
+      "47 6 * * 1"
+    ],
+    "name": "DATA onnx-light-cpu size and loc",
+    "path": ".github/workflows/record_size_onnx_light_cpu.yml"
+  },
+  {
+    "crons": [
+      "42 4 * * 1"
+    ],
+    "name": "DATA PR statistics",
+    "path": ".github/workflows/record_pr_stats.yml"
+  },
+  {
+    "crons": [
+      "43 6 * * 1"
+    ],
+    "name": "DATA PyPI downloads",
+    "path": ".github/workflows/record_pypi_downloads.yml"
+  },
+  {
+    "crons": [
+      "17 6 * * 1"
+    ],
+    "name": "DATA yobx size and loc",
+    "path": ".github/workflows/record_size_yobx.yml"
+  },
+  {
+    "crons": [
+      "23 7 * * 1"
+    ],
+    "name": "DATA yobx sklearn coverage",
+    "path": ".github/workflows/record_yobx_sklearn_coverage.yml"
+  },
+  {
+    "crons": [
+      "17 7 * * 1"
+    ],
+    "name": "DATA yobx torch coverage",
+    "path": ".github/workflows/record_torch_coverage.yml"
+  },
+  {
+    "crons": [
+      "37 7 1-7,15-21 * 1"
+    ],
+    "name": "DOC locodellm",
+    "path": ".github/workflows/build_locodellm_docs.yml"
+  },
+  {
+    "crons": [
+      "17 9 1-7,15-21 * 1"
+    ],
+    "name": "DOC mbext",
+    "path": ".github/workflows/build_mbext_docs.yml"
+  },
+  {
+    "crons": [
+      "17 7 1-7,15-21 * 1"
+    ],
+    "name": "DOC moa",
+    "path": ".github/workflows/build_my_own_accelerator_docs.yml"
+  },
+  {
+    "crons": [
+      "42 7 1-7,15-21 * 1"
+    ],
+    "name": "DOC onnx-light",
+    "path": ".github/workflows/build_onnx_light_docs.yml"
+  },
+  {
+    "crons": [
+      "57 7 1-7,15-21 * 1"
+    ],
+    "name": "DOC onnx-light-cpu",
+    "path": ".github/workflows/build_onnx_light_cpu_docs.yml"
+  },
+  {
+    "crons": [
+      "51 7 1-7,15-21 * 1"
+    ],
+    "name": "DOC onnx-light-kernel-images",
+    "path": ".github/workflows/build_onnx_light_kernel_images_docs.yml"
+  },
+  {
+    "crons": [
+      "42 8 1-7,15-21 * 1"
+    ],
+    "name": "DOC yaourt",
+    "path": ".github/workflows/build_yet_another_onnxruntime_extensions_docs.yml"
+  },
+  {
+    "crons": [
+      "17 8 1-7,15-21 * 1"
+    ],
+    "name": "DOC yobx",
+    "path": ".github/workflows/build_yet_another_onnx_builder_docs.yml"
+  },
+  {
+    "crons": [],
+    "name": "Run all DATA and DOC",
+    "path": ".github/workflows/run_all_data_and_doc.yml"
+  },
+  {
+    "crons": [],
+    "name": "Unit tests",
+    "path": ".github/workflows/unittest.yml"
+  }
+]

--- a/assets/workflow-status.js
+++ b/assets/workflow-status.js
@@ -1,0 +1,260 @@
+(function () {
+  "use strict";
+
+  var owner = "xadupre";
+  var repo = "xadupre.github.io";
+  var apiBase = "https://api.github.com/repos/" + owner + "/" + repo;
+  var runCacheKey = "workflow-status-runs-v1";
+  var runCacheLifetime = 15 * 60 * 1000;
+
+  function parseField(value, minimum, maximum, normalizeWeekday) {
+    var result = new Set();
+    value.split(",").forEach(function (part) {
+      var stepParts = part.split("/");
+      var range = stepParts[0];
+      var step = stepParts.length > 1 ? Number(stepParts[1]) : 1;
+      var bounds = range === "*" ? [minimum, maximum] : range.split("-").map(Number);
+      var start = bounds[0];
+      var end = bounds.length > 1 ? bounds[1] : bounds[0];
+      if (!Number.isInteger(step) || step < 1 || !Number.isInteger(start) ||
+          !Number.isInteger(end) || start < minimum || end > maximum || start > end) {
+        throw new Error("Unsupported cron field: " + value);
+      }
+      for (var current = start; current <= end; current += step) {
+        result.add(normalizeWeekday && current === 7 ? 0 : current);
+      }
+    });
+    return result;
+  }
+
+  function parseCron(expression) {
+    var fields = expression.trim().split(/\s+/);
+    if (fields.length !== 5) throw new Error("Expected five cron fields: " + expression);
+    return {
+      minute: parseField(fields[0], 0, 59, false),
+      hour: parseField(fields[1], 0, 23, false),
+      day: parseField(fields[2], 1, 31, false),
+      month: parseField(fields[3], 1, 12, false),
+      weekday: parseField(fields[4], 0, 7, true),
+      anyDay: fields[2] === "*",
+      anyWeekday: fields[4] === "*"
+    };
+  }
+
+  function matches(schedule, date) {
+    var dayMatches = schedule.day.has(date.getUTCDate());
+    var weekdayMatches = schedule.weekday.has(date.getUTCDay());
+    var calendarMatches;
+    if (schedule.anyDay && schedule.anyWeekday) {
+      calendarMatches = true;
+    } else if (schedule.anyDay) {
+      calendarMatches = weekdayMatches;
+    } else if (schedule.anyWeekday) {
+      calendarMatches = dayMatches;
+    } else {
+      calendarMatches = dayMatches || weekdayMatches;
+    }
+    return schedule.minute.has(date.getUTCMinutes()) &&
+      schedule.hour.has(date.getUTCHours()) &&
+      schedule.month.has(date.getUTCMonth() + 1) &&
+      calendarMatches;
+  }
+
+  function nextCron(expression, now) {
+    var schedule = parseCron(expression);
+    var candidate = new Date(now.getTime());
+    candidate.setUTCSeconds(0, 0);
+    candidate = new Date(candidate.getTime() + 60000);
+    var limit = 400 * 24 * 60;
+    for (var index = 0; index < limit; ++index) {
+      if (matches(schedule, candidate)) return candidate;
+      candidate = new Date(candidate.getTime() + 60000);
+    }
+    return null;
+  }
+
+  function nextWorkflowRun(crons, now) {
+    var dates = crons.map(function (cron) {
+      try {
+        return nextCron(cron, now);
+      } catch (_error) {
+        return null;
+      }
+    }).filter(Boolean);
+    if (!dates.length) return null;
+    return new Date(Math.min.apply(null, dates.map(function (date) { return date.getTime(); })));
+  }
+
+  function formatDate(value) {
+    if (!value) return "Never";
+    var date = value instanceof Date ? value : new Date(value);
+    if (isNaN(date.getTime())) return "Unknown";
+    return new Intl.DateTimeFormat(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      timeZone: "UTC",
+      timeZoneName: "short"
+    }).format(date);
+  }
+
+  function fetchJson(url) {
+    return fetch(url, {
+      headers: { "Accept": "application/vnd.github+json" },
+      cache: "no-store"
+    }).then(function (response) {
+      if (!response.ok) throw new Error("GitHub API returned " + response.status);
+      return response.json();
+    });
+  }
+
+  function loadRunCache(maximumAge) {
+    try {
+      var cached = JSON.parse(localStorage.getItem(runCacheKey));
+      if (!cached || !Array.isArray(cached.runs) ||
+          Date.now() - Number(cached.savedAt) > maximumAge) {
+        return null;
+      }
+      return new Map(cached.runs.map(function (run) { return [run.path, run]; }));
+    } catch (_error) {
+      return null;
+    }
+  }
+
+  function saveRunCache(latest) {
+    try {
+      localStorage.setItem(runCacheKey, JSON.stringify({
+        savedAt: Date.now(),
+        runs: Array.from(latest.values()).map(function (run) {
+          return {
+            path: run.path,
+            html_url: run.html_url,
+            run_started_at: run.run_started_at,
+            created_at: run.created_at,
+            status: run.status,
+            conclusion: run.conclusion
+          };
+        })
+      }));
+    } catch (_error) {
+      // The live result remains usable when browser storage is unavailable.
+    }
+  }
+
+  function fetchLatestRuns(paths) {
+    var cached = loadRunCache(runCacheLifetime);
+    if (cached) return Promise.resolve(cached);
+
+    var latest = new Map();
+    var wanted = new Set(paths);
+
+    function fetchPage(page) {
+      var url = apiBase + "/actions/runs?per_page=100&exclude_pull_requests=true&page=" + page;
+      return fetchJson(url).then(function (payload) {
+        var runs = payload.workflow_runs || [];
+        runs.forEach(function (run) {
+          if (wanted.has(run.path) && !latest.has(run.path)) latest.set(run.path, run);
+        });
+        if (latest.size === wanted.size || runs.length < 100 || page >= 10) return latest;
+        return fetchPage(page + 1);
+      });
+    }
+
+    return fetchPage(1).then(function (runs) {
+      saveRunCache(runs);
+      return runs;
+    }).catch(function (error) {
+      var stale = loadRunCache(Infinity);
+      if (!stale) throw error;
+      stale.isStale = true;
+      return stale;
+    });
+  }
+
+  function conclusionLabel(run) {
+    if (!run) return "";
+    if (run.status !== "completed") return run.status || "";
+    return run.conclusion || "completed";
+  }
+
+  function render(manifest, latestRuns) {
+    var tbody = document.getElementById("workflow-status-body");
+    var message = document.getElementById("workflow-status-message");
+    var now = new Date();
+    var rows = manifest.map(function (workflow) {
+      return {
+        workflow: workflow,
+        run: latestRuns.get(workflow.path),
+        next: nextWorkflowRun(workflow.crons || [], now)
+      };
+    });
+    rows.sort(function (left, right) {
+      if (left.next && right.next) return left.next - right.next;
+      if (left.next) return -1;
+      if (right.next) return 1;
+      return left.workflow.name.localeCompare(right.workflow.name);
+    });
+
+    tbody.textContent = "";
+    rows.forEach(function (item) {
+      var tr = document.createElement("tr");
+      var action = document.createElement("td");
+      var actionLink = document.createElement("a");
+      actionLink.href = "https://github.com/" + owner + "/" + repo + "/actions/workflows/" +
+        item.workflow.path.split("/").pop();
+      actionLink.textContent = item.workflow.name;
+      action.appendChild(actionLink);
+
+      var last = document.createElement("td");
+      if (item.run) {
+        var runLink = document.createElement("a");
+        runLink.href = item.run.html_url;
+        runLink.textContent = formatDate(item.run.run_started_at || item.run.created_at);
+        last.appendChild(runLink);
+        var conclusion = document.createElement("span");
+        conclusion.className = "workflow-conclusion workflow-" + conclusionLabel(item.run);
+        conclusion.textContent = conclusionLabel(item.run);
+        last.appendChild(conclusion);
+      } else {
+        last.textContent = "No run found";
+      }
+
+      var next = document.createElement("td");
+      next.textContent = item.next ? formatDate(item.next) : "Manual / event-driven";
+      if ((item.workflow.crons || []).length) {
+        next.title = item.workflow.crons.join(", ") + " (UTC)";
+      }
+      tr.appendChild(action);
+      tr.appendChild(last);
+      tr.appendChild(next);
+      tbody.appendChild(tr);
+    });
+    message.textContent = latestRuns.isStale ?
+      "Last runs are cached because the GitHub API is unavailable. Times are shown in UTC." :
+      "Times are shown in UTC. Scheduled times may be delayed by GitHub.";
+  }
+
+  function showError(error) {
+    var message = document.getElementById("workflow-status-message");
+    message.textContent = "Unable to load workflow runs: " + error.message;
+    message.className = "workflow-status-message workflow-error";
+  }
+
+  function init() {
+    fetchJson("assets/workflow-manifest.json").then(function (manifest) {
+      return fetchLatestRuns(manifest.map(function (workflow) {
+        return workflow.path;
+      })).then(function (latestRuns) {
+        render(manifest, latestRuns);
+      });
+    }).catch(showError);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -258,6 +258,64 @@ main ul {
   gap: 0.3em;
   width: auto;
 }
+.workflow-status {
+  margin: 2em auto 0;
+  padding-top: 1em;
+  border-top: 1px solid #30363d;
+  text-align: left;
+}
+.workflow-status h2 {
+  text-align: center;
+}
+.workflow-status-table-wrap {
+  overflow-x: auto;
+}
+.workflow-status table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.82em;
+}
+.workflow-status th,
+.workflow-status td {
+  padding: 0.55em 0.7em;
+  border-top: 1px solid #30363d;
+  vertical-align: top;
+}
+.workflow-status th {
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.82em;
+}
+.workflow-status th:first-child,
+.workflow-status td:first-child {
+  width: 42%;
+}
+.workflow-conclusion {
+  display: inline-block;
+  margin-left: 0.55em;
+  padding: 0.1em 0.4em;
+  border-radius: 0.5em;
+  color: #8b949e;
+  background: #21262d;
+  font-size: 0.85em;
+}
+.workflow-success { color: #3fb950; }
+.workflow-failure,
+.workflow-cancelled,
+.workflow-timed_out { color: #f85149; }
+.workflow-in_progress,
+.workflow-queued,
+.workflow-requested,
+.workflow-waiting { color: #d29922; }
+.workflow-status-message {
+  color: #8b949e;
+  text-align: center;
+  font-size: 0.75em;
+}
+.workflow-error {
+  color: #f85149;
+}
 @media (max-width: 600px) {
   main {
     padding: 1em;
@@ -1015,8 +1073,27 @@ main ul {
     </div>
   </div>
 </div>
+<section class="workflow-status" aria-labelledby="workflow-status-title">
+  <h2 id="workflow-status-title">GitHub Actions</h2>
+  <div class="workflow-status-table-wrap">
+    <table>
+      <thead>
+        <tr>
+          <th>Action</th>
+          <th>Last run</th>
+          <th>Next scheduled</th>
+        </tr>
+      </thead>
+      <tbody id="workflow-status-body">
+        <tr><td colspan="3">Loading workflow status...</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <p id="workflow-status-message" class="workflow-status-message"></p>
+</section>
 </main>
 <footer class="data-updated" data-source="cache_data/onnx/stats.csv" style="margin:1.5em auto 0.5em;font-size:0.75em;color:#8b949e;text-align:center;display:none;"></footer>
 <script src="assets/last-updated.js"></script>
+<script src="assets/workflow-status.js"></script>
 </body>
 </html>

--- a/scripts/generate_workflow_manifest.py
+++ b/scripts/generate_workflow_manifest.py
@@ -1,0 +1,53 @@
+"""Generates the workflow manifest displayed on the home page."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+DEFAULT_OUTPUT = ROOT / "assets" / "workflow-manifest.json"
+
+
+def build_manifest(workflows: Path = WORKFLOWS) -> list[dict[str, object]]:
+    """Builds the sorted workflow manifest."""
+    manifest = []
+    for path in sorted(workflows.glob("*.yml")):
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        triggers = data.get("on", data.get(True, {})) or {}
+        schedules = triggers.get("schedule", []) if isinstance(triggers, dict) else []
+        crons = [
+            item["cron"]
+            for item in schedules
+            if isinstance(item, dict) and isinstance(item.get("cron"), str)
+        ]
+        manifest.append(
+            {
+                "name": data.get("name", path.stem),
+                "path": f".github/workflows/{path.name}",
+                "crons": crons,
+            }
+        )
+    return sorted(
+        manifest, key=lambda item: (str(item["name"]).lower(), str(item["path"]))
+    )
+
+
+def main() -> None:
+    """Writes the workflow manifest."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    args = parser.parse_args()
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(build_manifest(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_generate_workflow_manifest.py
+++ b/scripts/tests/test_generate_workflow_manifest.py
@@ -1,0 +1,61 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+import yaml
+
+HERE = os.path.dirname(__file__)
+ROOT = os.path.dirname(os.path.dirname(HERE))
+sys.path.insert(0, os.path.join(ROOT, "scripts"))
+
+import generate_workflow_manifest as generator
+
+
+class TestGenerateWorkflowManifest(unittest.TestCase):
+    def test_manifest_matches_workflow_files(self):
+        manifest = generator.build_manifest()
+        paths = {item["path"] for item in manifest}
+        expected = {
+            f".github/workflows/{name}"
+            for name in os.listdir(os.path.join(ROOT, ".github", "workflows"))
+            if name.endswith(".yml")
+        }
+        self.assertEqual(paths, expected)
+        self.assertEqual(len(paths), len(manifest))
+        self.assertTrue(all(item["name"] for item in manifest))
+
+    def test_crons_match_workflow_definitions(self):
+        for item in generator.build_manifest():
+            path = os.path.join(ROOT, item["path"])
+            with open(path, encoding="utf-8") as stream:
+                data = yaml.safe_load(stream)
+            triggers = data.get("on", data.get(True, {})) or {}
+            schedules = (
+                triggers.get("schedule", []) if isinstance(triggers, dict) else []
+            )
+            self.assertEqual(
+                item["crons"], [schedule["cron"] for schedule in schedules]
+            )
+
+    def test_cli_writes_current_manifest(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            output = os.path.join(temporary, "manifest.json")
+            subprocess.run(
+                [sys.executable, generator.__file__, "--output", output],
+                check=True,
+                cwd=ROOT,
+            )
+            with open(output, encoding="utf-8") as stream:
+                self.assertEqual(json.load(stream), generator.build_manifest())
+
+    def test_committed_manifest_is_current(self):
+        path = os.path.join(ROOT, "assets", "workflow-manifest.json")
+        with open(path, encoding="utf-8") as stream:
+            self.assertEqual(json.load(stream), generator.build_manifest())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- list all repository workflows on the home page
- link each workflow and its latest run, including the run conclusion
- compute the next scheduled UTC execution from each workflow cron
- cache paginated GitHub API results for 15 minutes
- generate and test the workflow manifest from the YAML definitions

## Validation
- `python -m unittest discover -s scripts/tests -p 'test_generate_workflow_manifest.py' -v`\n- `black --check scripts/generate_workflow_manifest.py scripts/tests/test_generate_workflow_manifest.py`\n- `ruff check scripts/generate_workflow_manifest.py scripts/tests/test_generate_workflow_manifest.py`\n- `git diff --check`