### PR TITLE
Improve CPU benchmark table details

### DIFF
--- a/dashboard/onnx-light-cpu/cpu-benchmark.html
+++ b/dashboard/onnx-light-cpu/cpu-benchmark.html
@@ -136,7 +136,13 @@ table.benchmark th, table.benchmark td {
   white-space: nowrap;
 }
 table.benchmark th { color: #8b949e; font-weight: normal; }
-table.benchmark th:first-child, table.benchmark td:first-child { text-align: left; }
+table.benchmark th:first-child, table.benchmark td:first-child,
+table.benchmark th:nth-child(2), table.benchmark td:nth-child(2) { text-align: left; }
+table.benchmark th.sortable { cursor: pointer; user-select: none; }
+table.benchmark th.sortable:hover { color: #c9d1d9; }
+table.benchmark th.sortable:focus-visible { outline: 2px solid #58a6ff; outline-offset: -2px; }
+table.benchmark th[aria-sort="ascending"]::after { content: " ▲"; }
+table.benchmark th[aria-sort="descending"]::after { content: " ▼"; }
 table.benchmark td.faster { color: #3fb950; font-weight: bold; }
 table.benchmark td.slower { color: #f85149; font-weight: bold; }
 table.benchmark td.neutral { color: #bc8cff; font-weight: bold; }
@@ -279,12 +285,14 @@ function fmtSpeedup(value) {
 function formatBenchmarkDate(value) {
   const date = new Date(value);
   if (!value || Number.isNaN(date.getTime())) return "—";
-  return date.toISOString().replace("T", " ").slice(0, 16) + " UTC";
+  return date.toISOString().slice(0, 10);
 }
 
 function renderMeta(payload) {
   document.getElementById("metaPanel").style.display = "block";
-  document.getElementById("metaDate").textContent = payload.date || "(unknown date)";
+  document.getElementById("metaDate").textContent = payload.date
+    ? formatBenchmarkDate(payload.date)
+    : "(unknown date)";
   if (payload.n_warmup !== undefined) {
     document.getElementById("nWarmupLabel").textContent = payload.n_warmup;
   }
@@ -358,6 +366,53 @@ function firstInputTensor(row) {
 function firstInputType(row) {
   const first = firstInputTensor(row).split("[")[0].trim();
   return /^[A-Za-z_][A-Za-z0-9_]*$/.test(first) ? first : "";
+}
+
+function makeSortable(table) {
+  const headers = Array.from(table.querySelectorAll("thead th"));
+  headers.forEach((header, column) => {
+    header.classList.add("sortable");
+    header.tabIndex = 0;
+    header.title = "Sort by " + header.textContent;
+    const sort = () => {
+      const ascending = header.dataset.direction !== "asc";
+      headers.forEach(other => {
+        delete other.dataset.direction;
+        other.removeAttribute("aria-sort");
+      });
+      header.dataset.direction = ascending ? "asc" : "desc";
+      header.setAttribute("aria-sort", ascending ? "ascending" : "descending");
+      const tbody = table.tBodies[0];
+      const rows = Array.from(tbody.rows).map((row, index) => ({ row, index }));
+      const numeric = header.dataset.sortType === "number";
+      rows.sort((left, right) => {
+        const leftValue = left.row.cells[column].dataset.sortValue || "";
+        const rightValue = right.row.cells[column].dataset.sortValue || "";
+        let comparison;
+        if (numeric) {
+          const leftNumber = leftValue === "" ? null : Number(leftValue);
+          const rightNumber = rightValue === "" ? null : Number(rightValue);
+          if (leftNumber === null) comparison = rightNumber === null ? 0 : 1;
+          else if (rightNumber === null) comparison = -1;
+          else comparison = leftNumber - rightNumber;
+        } else {
+          comparison = leftValue.localeCompare(rightValue, undefined, {
+            numeric: true,
+            sensitivity: "base",
+          });
+        }
+        return (ascending ? comparison : -comparison) || left.index - right.index;
+      });
+      rows.forEach(item => tbody.appendChild(item.row));
+    };
+    header.addEventListener("click", sort);
+    header.addEventListener("keydown", event => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        sort();
+      }
+    });
+  });
 }
 
 function renderExample(example, cats, benchmarkDate) {
@@ -435,6 +490,9 @@ function renderExample(example, cats, benchmarkDate) {
 
   const thead = document.createElement("thead");
   const htr = document.createElement("tr");
+  const nameTh = document.createElement("th");
+  nameTh.textContent = "test name";
+  htr.appendChild(nameTh);
   const typeTh = document.createElement("th");
   typeTh.textContent = "first input tensor";
   htr.appendChild(typeTh);
@@ -444,10 +502,12 @@ function renderExample(example, cats, benchmarkDate) {
   backends.forEach(b => {
     const th = document.createElement("th");
     th.innerHTML = (BACKEND_LABELS[b] || b) + " (ms)";
+    th.dataset.sortType = "number";
     htr.appendChild(th);
   });
   const spTh = document.createElement("th");
   spTh.textContent = "speed-up (cpu)";
+  spTh.dataset.sortType = "number";
   htr.appendChild(spTh);
   thead.appendChild(htr);
   table.appendChild(thead);
@@ -455,31 +515,50 @@ function renderExample(example, cats, benchmarkDate) {
   const tbody = document.createElement("tbody");
   (example.rows || []).forEach(row => {
     const tr = document.createElement("tr");
+    const nameTd = document.createElement("td");
+    if (row.test_name) {
+      const code = document.createElement("code");
+      code.textContent = row.test_name;
+      nameTd.appendChild(code);
+      nameTd.dataset.sortValue = row.test_name;
+    } else {
+      nameTd.textContent = "—";
+    }
+    tr.appendChild(nameTd);
     const typeTd = document.createElement("td");
     const inputTensor = firstInputTensor(row);
     if (inputTensor) {
       const code = document.createElement("code");
       code.textContent = inputTensor;
       typeTd.appendChild(code);
+      typeTd.dataset.sortValue = inputTensor;
     } else {
       typeTd.textContent = "—";
     }
     tr.appendChild(typeTd);
     const dateTd = document.createElement("td");
     dateTd.textContent = formatBenchmarkDate(benchmarkDate);
+    dateTd.dataset.sortValue = dateTd.textContent === "—" ? "" : dateTd.textContent;
     tr.appendChild(dateTd);
     backends.forEach(b => {
       const td = document.createElement("td");
       td.textContent = fmtMs(row[b + "_ms"]);
+      if (row[b + "_ms"] !== null && row[b + "_ms"] !== undefined) {
+        td.dataset.sortValue = row[b + "_ms"];
+      }
       tr.appendChild(td);
     });
     const spTd = document.createElement("td");
     spTd.textContent = fmtSpeedup(row.speedup_cpu);
     spTd.className = speedupClass(row.speedup_cpu);
+    if (row.speedup_cpu !== null && row.speedup_cpu !== undefined) {
+      spTd.dataset.sortValue = row.speedup_cpu;
+    }
     tr.appendChild(spTd);
     tbody.appendChild(tr);
   });
   table.appendChild(tbody);
+  makeSortable(table);
   wrap.appendChild(table);
   details.appendChild(wrap);
 

--- a/scripts/record_onnx_light_cpu_benchmark.py
+++ b/scripts/record_onnx_light_cpu_benchmark.py
@@ -117,22 +117,24 @@ def _group_measurements(
                 "op": operator,
                 "backends": list(BENCHMARK_BACKENDS),
                 "rows": [],
-                "test_names": [],
             },
         )
+        row["test_name"] = measurement["test_name"]
         group["rows"].append(row)
-        group["test_names"].append(measurement["test_name"])
 
     examples: list[dict[str, Any]] = []
     for group in groups.values():
         rows = sorted(
             group.pop("rows"),
-            key=lambda row: (row.get("input_elements", 0), row["inputs"]),
+            key=lambda row: (
+                row.get("input_elements", 0),
+                row["inputs"],
+                row["test_name"],
+            ),
         )
-        test_names = group.pop("test_names")
         speedups = [row["speedup_cpu"] for row in rows if "speedup_cpu" in row]
         group["rows"] = rows
-        group["source"] = f"{len(test_names)} onnx-light-cpu benchmark tests"
+        group["source"] = f"{len(rows)} onnx-light-cpu benchmark tests"
         group["summary"] = {
             "inputs": len(rows),
             "cpu_succeeded": len(speedups),

--- a/scripts/tests/test_examples_benchmark_dashboard.py
+++ b/scripts/tests/test_examples_benchmark_dashboard.py
@@ -80,6 +80,12 @@ class TestExamplesBenchmarkDashboard(unittest.TestCase):
         self.assertIn('firstInputTensor(row).split("[")[0].trim()', text)
         self.assertIn("code.textContent = inputTensor;", text)
 
+    def test_expanded_table_shows_test_names(self):
+        text = _read(PAGE)
+        self.assertIn('nameTh.textContent = "test name";', text)
+        self.assertIn("if (row.test_name)", text)
+        self.assertIn("code.textContent = row.test_name;", text)
+
     def test_summary_and_rows_show_the_benchmark_date(self):
         text = _read(PAGE)
         self.assertEqual(text.count("<span>date</span>"), 1)
@@ -87,6 +93,17 @@ class TestExamplesBenchmarkDashboard(unittest.TestCase):
         self.assertIn('dateTh.textContent = "date";', text)
         self.assertIn("dateTd.textContent = formatBenchmarkDate(benchmarkDate);", text)
         self.assertIn("renderExample(ex, cats, payload.date)", text)
+        self.assertIn('return date.toISOString().slice(0, 10);', text)
+        self.assertIn("? formatBenchmarkDate(payload.date)", text)
+
+    def test_expanded_tables_are_sortable(self):
+        text = _read(PAGE)
+        self.assertIn("function makeSortable(table)", text)
+        self.assertIn('header.addEventListener("click", sort);', text)
+        self.assertIn('header.setAttribute("aria-sort"', text)
+        self.assertIn("makeSortable(table);", text)
+        self.assertIn('th[aria-sort="ascending"]::after', text)
+        self.assertIn('th[aria-sort="descending"]::after', text)
 
     def test_panels_are_sorted_by_operator(self):
         text = _read(PAGE)

--- a/scripts/tests/test_record_onnx_light_cpu_benchmark.py
+++ b/scripts/tests/test_record_onnx_light_cpu_benchmark.py
@@ -99,6 +99,13 @@ class TestRows(unittest.TestCase):
             [row["inputs"] for row in float32["rows"]],
             ["float32[1024]", "float32[65536]"],
         )
+        self.assertEqual(
+            [row["test_name"] for row in float32["rows"]],
+            [
+                "test_cpu_abs_n1024_benchmark",
+                "test_cpu_abs_n65536_benchmark",
+            ],
+        )
         self.assertEqual(float32["summary"]["inputs"], 2)
         self.assertEqual(float32["summary"]["avg_speedup_cpu"], 1.5)
         self.assertEqual(float32["summary"]["min_speedup_cpu"], 1.0)


### PR DESCRIPTION
## Summary
- preserve and display each benchmark test name
- show benchmark dates without the time component
- make every expanded-table column sortable with keyboard support and sort indicators

## Validation
- `python scripts/tests/test_record_onnx_light_cpu_benchmark.py`
- `python scripts/tests/test_examples_benchmark_dashboard.py`
- `python scripts/tests/test_last_updated_footer.py`

The current cache changed concurrently from 94 to 506 rows, so this PR intentionally leaves it untouched. Test names will populate when the benchmark recording workflow next regenerates the snapshot.