### PR TITLE
Isolate and bound dashboard benchmark phases

### DIFF
--- a/dashboard/benchmark-methodology.html
+++ b/dashboard/benchmark-methodology.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Benchmark methodology</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<link rel="icon" type="image/svg+xml" href="../logo.svg" />
+<style>
+body {
+  background: #0d1117;
+  color: #c9d1d9;
+  font-family: sans-serif;
+  line-height: 1.55;
+  margin: 0 auto;
+  max-width: 900px;
+  padding: 2em;
+}
+a { color: #58a6ff; }
+h1, h2 { color: #f0f6fc; }
+code {
+  background: rgba(110, 118, 129, 0.4);
+  border-radius: 4px;
+  padding: 0 0.3em;
+}
+</style>
+</head>
+<body>
+<p><a href="../index.html">&larr; back to home</a></p>
+<h1>Benchmark methodology</h1>
+<p>
+  CPU benchmarks are sensitive to persistent worker pools, allocator reuse,
+  lazy preparation, and runtime caches. The onnx-light dashboards therefore
+  separate competing runtimes into global phases instead of alternating them
+  for each test.
+</p>
+<h2>Runtime phases</h2>
+<p>
+  Models and inputs are prepared first. Every plain <code>onnx-light</code>
+  case runs before the process-wide <code>onnx-light-cpu</code> kernels are
+  registered. Every <code>onnx-light-cpu</code> case then runs before any
+  ONNX Runtime session is constructed. Sessions are released and garbage
+  collection runs between phases.
+</p>
+<p>
+  Each runtime keeps its documented default worker-spin policy. Changing the
+  spin policy would change the runtime being measured; phase separation
+  prevents a live session from one runtime perturbing another runtime's timed
+  phase.
+</p>
+<h2>Sampling</h2>
+<p>
+  Warm-up calls are untimed. A measurement stops when its requested repetition
+  count is reached or after two seconds of cumulative measured execution,
+  whichever comes first. A call already in progress finishes normally. The
+  dashboard records the actual sample count and reports the existing trimmed
+  mean or median defined by each recorder.
+</p>
+<h2>Interpretation</h2>
+<p>
+  Models and logical inputs are identical across backends. Published dashboard
+  results come from shared CI machines and are diagnostic rather than stable
+  performance gates. Runtime versions, SIMD selection, dates, and raw timing
+  ranges should be considered before comparing snapshots.
+</p>
+</body>
+</html>

--- a/dashboard/onnx-light-cpu/cpu-benchmark.html
+++ b/dashboard/onnx-light-cpu/cpu-benchmark.html
@@ -174,7 +174,10 @@ table.benchmark tbody tr:hover { background: rgba(56, 139, 253, 0.08); }
 </head>
 <body>
 <header>
-  <div class="nav"><a href="../../index.html">&larr; back to home</a></div>
+  <div class="nav">
+    <a href="../../index.html">&larr; back to home</a> &middot;
+    <a href="../benchmark-methodology.html">methodology</a>
+  </div>
   <h1>onnx-light-cpu &mdash; benchmark</h1>
   <p class="intro">
     Processing time comparison between
@@ -187,9 +190,11 @@ table.benchmark tbody tr:hover { background: rgba(56, 139, 253, 0.08); }
     <em>big models</em> exposed by <code>onnx&#8209;light</code>. Each gallery
     example exercises an operator over a range of inputs and shows
     <code>numpy</code> as a baseline; each big model is a single larger graph
-    from onnx&#8209;light's benchmark corpus. Every measurement runs
-    <strong id="nWarmupLabel">3</strong> warm-up calls (not timed) and keeps the
-    median of <strong id="nMeasureLabel">10</strong> timed repetitions.
+    from onnx&#8209;light's benchmark corpus. Backends run in separate global
+    phases with their default spin policies. Every measurement runs
+    <strong id="nWarmupLabel">3</strong> warm-up calls (not timed) and uses up
+    to <strong id="nMeasureLabel">10</strong> timed repetitions, stopping after
+    two seconds of cumulative measured execution.
     <strong>speed-up (cpu)</strong> = <code>onnxruntime</code> /
     <code>onnx&#8209;light&#8209;cpu</code>: values&nbsp;&gt;&nbsp;1 mean
     onnx&#8209;light&#8209;cpu is faster than onnxruntime. Select an operator

--- a/dashboard/onnx-light/benchmark.html
+++ b/dashboard/onnx-light/benchmark.html
@@ -259,7 +259,10 @@ table.benchmark tr.graph-row > td {
 </head>
 <body>
 <header>
-  <div class="nav"><a href="../../index.html">&larr; back to home</a></div>
+  <div class="nav">
+    <a href="../../index.html">&larr; back to home</a> &middot;
+    <a href="../benchmark-methodology.html">methodology</a>
+  </div>
   <h1>onnx-light &mdash; benchmark</h1>
   <p class="intro">
     Processing time comparison between
@@ -267,8 +270,10 @@ table.benchmark tr.graph-row > td {
     <code>onnx-light</code> reference evaluator backed by its C++ kernel
     dispatch table (<code>onnx_light.reference.ReferenceEvaluator</code>)
     on every ONNX backend node test.
+    Backends run in separate global phases with their default spin policies.
     Each test runs <strong id="nWarmupLabel">3</strong> warm-up iterations
-    (not timed) and <strong id="nMeasureLabel">10</strong> timed iterations;
+    (not timed) and up to <strong id="nMeasureLabel">10</strong> timed
+    iterations, stopping after two seconds of cumulative measured execution;
     the <em>average</em> time per dataset is reported (a trimmed mean that
     excludes the fastest and slowest timed iterations; hover a cell for the
     raw min/max).

--- a/scripts/record_onnx_light_benchmark.py
+++ b/scripts/record_onnx_light_benchmark.py
@@ -20,12 +20,17 @@ built-in ``onnx-light`` pass over every test runs before the
 resolves each kernel once and replays the cached execution plan on subsequent
 runs.
 
-For each test the measurement protocol is:
+The benchmark runs every test through ``onnx-light``, then every test through
+``onnx-light-cpu``, and finally every test through ONNX Runtime. Sessions from
+one phase are released before the next phase starts, so each runtime keeps its
+default worker-spin policy without perturbing another runtime's measurements.
 
-1. Configure both runtimes to park idle workers immediately, then load /
-   compile the model once (not timed).
+For each backend and test the measurement protocol is:
+
+1. Load / compile the model once (not timed).
 2. Run :data:`N_WARMUP` iterations to prime the JIT / kernel cache.
-3. Run :data:`N_MEASURE` iterations and record the wall-clock time of each.
+3. Run up to :data:`N_MEASURE` iterations, stopping after two seconds of
+   cumulative measured execution, and record the wall-clock time of each.
 4. Report the per-backend **average** execution time
    (in milliseconds), computed as a trimmed mean that discards the fastest
    and slowest timed iterations, along with the raw ``min``/``max`` samples,
@@ -67,6 +72,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import gc
 import json
 import os
 import sys
@@ -104,9 +110,15 @@ N_WARMUP: int = 3
 #: Default number of timed iterations used to compute the average time.
 N_MEASURE: int = 10
 
+MAX_MEASURE_DURATION_S: float = 2.0
+
 DEFAULT_KIND: str = "node"
 
-ONNX_LIGHT_CPU_EXECUTION: Dict[str, str] = {"spin_policy": "park_immediately"}
+BENCHMARK_EXECUTION_ORDER: Tuple[str, ...] = (
+    "onnx_light",
+    "onnx_light_cpu",
+    "onnxruntime",
+)
 
 #: Suffix identifying the genuine benchmark-sized backend test cases. In
 #: ``TestMode.BENCHMARK`` mode ``onnx-light`` registers large, benchmark-sized
@@ -533,12 +545,8 @@ def discover_node_tests(kind: str = DEFAULT_KIND) -> List[Dict[str, Any]]:
 def _make_onnxruntime_runner(model) -> Callable[[List[Any]], List[Any]]:
     import onnxruntime
 
-    options = onnxruntime.SessionOptions()
-    options.add_session_config_entry("session.intra_op.allow_spinning", "0")
-    options.add_session_config_entry("session.inter_op.allow_spinning", "0")
     sess = onnxruntime.InferenceSession(
         model.SerializeToString(),
-        sess_options=options,
         providers=["CPUExecutionProvider"],
     )
     input_names = [i.name for i in sess.get_inputs()]
@@ -569,9 +577,7 @@ def _make_onnx_light_reference_runner(
     if register is not None:
         register()
 
-    evaluator = ReferenceEvaluator(
-        model.SerializeToString(), cpu_execution=ONNX_LIGHT_CPU_EXECUTION
-    )
+    evaluator = ReferenceEvaluator(model.SerializeToString())
     input_names = evaluator.input_names
 
     def _run(inputs: List[Any]) -> List[Any]:
@@ -733,6 +739,7 @@ def run_benchmark(
     backend: str,
     n_warmup: int = N_WARMUP,
     n_measure: int = N_MEASURE,
+    max_measure_duration_s: float = MAX_MEASURE_DURATION_S,
 ) -> Dict[str, Any]:
     """Run a benchmark for ``backend`` on ``model`` / ``data_sets``.
 
@@ -790,6 +797,7 @@ def run_benchmark(
 
     # --- Timed measurement iterations ---------------------------------------
     times_ms: List[float] = []
+    total_elapsed_s = 0.0
     for _ in range(n_measure):
         t0 = time.perf_counter()
         for inputs, _ in data_sets:
@@ -803,8 +811,12 @@ def run_benchmark(
                     "n_warmup": n_warmup,
                     "n_measure": len(times_ms),
                 }
-        elapsed_ms = (time.perf_counter() - t0) * 1_000
+        elapsed_s = time.perf_counter() - t0
+        elapsed_ms = elapsed_s * 1_000
         times_ms.append(elapsed_ms)
+        total_elapsed_s += elapsed_s
+        if total_elapsed_s >= max_measure_duration_s:
+            break
 
     if not times_ms:
         return {
@@ -833,7 +845,7 @@ def run_benchmark(
         "min_ms": round(sorted_ms[0], 6),
         "max_ms": round(sorted_ms[-1], 6),
         "n_warmup": n_warmup,
-        "n_measure": n_measure,
+        "n_measure": len(times_ms),
     }
 
 
@@ -1161,16 +1173,8 @@ def build_payload(
                 "error_step": "run",
             }
 
-    # ``onnx_light_cpu`` installs its SIMD kernels into onnx-light's shared C++
-    # dispatch table globally and irreversibly (there is no un-register hook), so
-    # it is deferred to a second pass: the built-in ``onnx_light`` backend is
-    # timed for every test first to keep that baseline unaffected by the
-    # registration.
-    deferred = "onnx_light_cpu"
-    first_pass_backends = [b for b in BENCHMARK_BACKENDS if b != deferred]
-
     per_test: List[Dict[str, Any]] = []
-    for idx, test in enumerate(tests):
+    for test in tests:
         name = test["name"]
         model = test["model"]
         data_sets = test["data_sets"]
@@ -1186,16 +1190,12 @@ def build_payload(
         cost_n = _symbolic_cost(data_sets, operator, model)
         input_type = _first_input_type(data_sets)
 
-        results: Dict[str, Dict[str, Any]] = {}
-        for backend in first_pass_backends:
-            results[backend] = _benchmark(name, model, data_sets, backend)
-
         per_test.append(
             {
                 "name": name,
                 "tag": tag,
                 "graph": graph,
-                "results": results,
+                "results": {},
                 "cost_n": cost_n,
                 "cost_complexity": cost_complexity,
                 "operator": operator,
@@ -1203,18 +1203,17 @@ def build_payload(
             }
         )
 
-        if (idx + 1) % 50 == 0:
-            _log(f"Benchmarked {idx + 1}/{len(tests)} tests (built-in backends).")
-
-    # Second pass: the ``onnx_light_cpu`` backend registers its SIMD kernels on
-    # first use, after which every onnx-light run dispatches to them.
-    if deferred in BENCHMARK_BACKENDS:
+    # The plain onnx-light phase must precede onnx-light-cpu because registering
+    # the accelerated kernels is process-wide and irreversible. ONNX Runtime is
+    # measured last, after all onnx-light sessions have been released.
+    for backend in BENCHMARK_EXECUTION_ORDER:
         for idx, (test, entry) in enumerate(zip(tests, per_test)):
-            entry["results"][deferred] = _benchmark(
-                entry["name"], test["model"], test["data_sets"], deferred
+            entry["results"][backend] = _benchmark(
+                entry["name"], test["model"], test["data_sets"], backend
             )
             if (idx + 1) % 50 == 0:
-                _log(f"Benchmarked {idx + 1}/{len(tests)} tests (onnx-light-cpu).")
+                _log(f"Benchmarked {idx + 1}/{len(tests)} tests ({backend}).")
+        gc.collect()
 
     rows: List[Dict[str, Any]] = [
         _row_from_results(
@@ -1229,7 +1228,6 @@ def build_payload(
         )
         for entry in per_test
     ]
-
 
     # Summary stats across all tests that both backends succeeded on.
     both_ok = [

--- a/scripts/record_onnx_light_cpu_benchmark.py
+++ b/scripts/record_onnx_light_cpu_benchmark.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import gc
 import json
 import math
 import os
@@ -165,29 +166,39 @@ def run_tests(
     run: Callable[..., dict[str, Any]] = rlb.run_benchmark,
 ) -> list[dict[str, Any]]:
     """Benchmark the supplied onnx-light-cpu cases."""
-    measurements: list[dict[str, Any]] = []
+    cpu_results = []
     for test in tests:
-        model = test["model"]
+        cpu_results.append(
+            run(
+                test["model"],
+                test["data_sets"],
+                "onnx_light_cpu",
+                n_warmup=n_warmup,
+                n_measure=n_measure,
+            )
+        )
+    gc.collect()
+
+    ort_results = []
+    for test in tests:
+        ort_results.append(
+            run(
+                test["model"],
+                test["data_sets"],
+                "onnxruntime",
+                n_warmup=n_warmup,
+                n_measure=n_measure,
+            )
+        )
+
+    measurements: list[dict[str, Any]] = []
+    for test, cpu, ort in zip(tests, cpu_results, ort_results, strict=True):
         data_sets = test["data_sets"]
-        cpu = run(
-            model,
-            data_sets,
-            "onnx_light_cpu",
-            n_warmup=n_warmup,
-            n_measure=n_measure,
-        )
-        ort = run(
-            model,
-            data_sets,
-            "onnxruntime",
-            n_warmup=n_warmup,
-            n_measure=n_measure,
-        )
         first_inputs = data_sets[0][0]
         inputs = _format_inputs(first_inputs)
         row = _row(inputs, cpu, ort)
         row["input_elements"] = _first_input_element_count(first_inputs)
-        operator = rlb._operator_name(model) or "?"
+        operator = rlb._operator_name(test["model"]) or "?"
         measurements.append(
             {
                 "operator": operator,

--- a/scripts/tests/test_benchmark_dashboard.py
+++ b/scripts/tests/test_benchmark_dashboard.py
@@ -8,6 +8,7 @@ import unittest
 HERE = os.path.dirname(os.path.abspath(__file__))
 REPO_ROOT = os.path.normpath(os.path.join(HERE, "..", ".."))
 PAGE = os.path.join(REPO_ROOT, "dashboard", "onnx-light", "benchmark.html")
+METHODOLOGY = os.path.join(REPO_ROOT, "dashboard", "benchmark-methodology.html")
 
 
 def _read(path: str) -> str:
@@ -18,6 +19,13 @@ def _read(path: str) -> str:
 class TestBenchmarkDashboard(unittest.TestCase):
     def test_page_exists(self):
         self.assertTrue(os.path.isfile(PAGE), f"missing page: {PAGE}")
+
+    def test_page_links_benchmark_methodology(self):
+        text = _read(PAGE)
+        self.assertIn('href="../benchmark-methodology.html"', text)
+        methodology = _read(METHODOLOGY)
+        self.assertIn("separate competing runtimes into global phases", methodology)
+        self.assertIn("two seconds of cumulative measured execution", methodology)
 
     def test_input_type_column_present(self):
         text = _read(PAGE)

--- a/scripts/tests/test_examples_benchmark_dashboard.py
+++ b/scripts/tests/test_examples_benchmark_dashboard.py
@@ -9,6 +9,7 @@ import unittest
 HERE = os.path.dirname(os.path.abspath(__file__))
 REPO_ROOT = os.path.normpath(os.path.join(HERE, "..", ".."))
 PAGE = os.path.join(REPO_ROOT, "dashboard", "onnx-light-cpu", "cpu-benchmark.html")
+METHODOLOGY = os.path.join(REPO_ROOT, "dashboard", "benchmark-methodology.html")
 INDEX = os.path.join(REPO_ROOT, "index.html")
 WORKFLOW = os.path.join(
     REPO_ROOT, ".github", "workflows", "record_onnx_light_cpu_examples_benchmark.yml"
@@ -25,6 +26,11 @@ def _read(path: str) -> str:
 class TestExamplesBenchmarkDashboard(unittest.TestCase):
     def test_page_exists(self):
         self.assertTrue(os.path.isfile(PAGE), f"missing page: {PAGE}")
+
+    def test_page_links_benchmark_methodology(self):
+        text = _read(PAGE)
+        self.assertIn('href="../benchmark-methodology.html"', text)
+        self.assertTrue(os.path.isfile(METHODOLOGY))
 
     def test_page_loads_the_expected_json(self):
         text = _read(PAGE)
@@ -93,7 +99,7 @@ class TestExamplesBenchmarkDashboard(unittest.TestCase):
         self.assertIn('dateTh.textContent = "date";', text)
         self.assertIn("dateTd.textContent = formatBenchmarkDate(benchmarkDate);", text)
         self.assertIn("renderExample(ex, cats, payload.date)", text)
-        self.assertIn('return date.toISOString().slice(0, 10);', text)
+        self.assertIn("return date.toISOString().slice(0, 10);", text)
         self.assertIn("? formatBenchmarkDate(payload.date)", text)
 
     def test_expanded_table_puts_speedup_immediately_after_date(self):

--- a/scripts/tests/test_record_onnx_light_benchmark.py
+++ b/scripts/tests/test_record_onnx_light_benchmark.py
@@ -76,13 +76,7 @@ class TestOnnxruntimeRunner(unittest.TestCase):
         # The serialized model is passed through unchanged on the CPU provider.
         self.assertEqual(created[0][0], b"corpus-model")
         self.assertEqual(created[0][2], ["CPUExecutionProvider"])
-        self.assertEqual(
-            created[0][1].entries,
-            {
-                "session.intra_op.allow_spinning": "0",
-                "session.inter_op.allow_spinning": "0",
-            },
-        )
+        self.assertIsNone(created[0][1])
         self.assertEqual(runner([]), ["output"])
 
     def test_session_error_propagates(self):
@@ -449,6 +443,37 @@ class TestRunBenchmark(unittest.TestCase):
         # avg drops 0.0 and 100.0, leaving [1.0, 1.0, 1.0] -> 1.0.
         self.assertAlmostEqual(result["avg_ms"], 1.0, places=6)
 
+    def test_measurement_stops_after_cumulative_duration(self):
+        ticks = iter((0.0, 1.1))
+
+        def _dummy_factory(model):
+            return lambda inputs: [np.zeros((1,))]
+
+        saved = rlb._RUNNER_FACTORIES.get("onnxruntime")
+        saved_pc = rlb.time.perf_counter
+        try:
+            rlb._RUNNER_FACTORIES["onnxruntime"] = _dummy_factory
+            rlb.time.perf_counter = lambda: next(ticks)
+            result = rlb.run_benchmark(
+                object(),
+                [([np.ones((1,))], [np.zeros((1,))])],
+                "onnxruntime",
+                n_warmup=1,
+                n_measure=5,
+                max_measure_duration_s=1.0,
+            )
+        finally:
+            rlb.time.perf_counter = saved_pc
+            if saved is None:
+                del rlb._RUNNER_FACTORIES["onnxruntime"]
+            else:
+                rlb._RUNNER_FACTORIES["onnxruntime"] = saved
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["n_warmup"], 1)
+        self.assertEqual(result["n_measure"], 1)
+        self.assertEqual(result["avg_ms"], 1100.0)
+
 
 class TestSymbolicCost(unittest.TestCase):
     def test_none_when_no_data_sets(self):
@@ -729,6 +754,10 @@ class TestBuildPayload(unittest.TestCase):
         for backend, nw, nm in call_log:
             self.assertEqual(nw, 2)
             self.assertEqual(nm, 7)
+        self.assertEqual(
+            [backend for backend, _, _ in call_log],
+            [backend for backend in rlb.BENCHMARK_EXECUTION_ORDER for _ in range(2)],
+        )
 
         # test_abs and test_relu both succeeded on both backends → speedup set.
         for row in payload["tests"]:
@@ -1072,9 +1101,7 @@ class TestOnnxLightReferenceRunner(unittest.TestCase):
         self.assertEqual(telemetry["sessions"], 1)
         self.assertEqual(telemetry["runs"], 2)
         self.assertIs(telemetry["feeds"][0]["x"], first_input)
-        self.assertEqual(
-            telemetry["cpu_execution"], {"spin_policy": "park_immediately"}
-        )
+        self.assertIsNone(telemetry["cpu_execution"])
 
     def test_make_onnx_light_runner_uses_runtime_session(self):
         """The onnx_light backend runs through the ``RuntimeSession`` path, the

--- a/scripts/tests/test_record_onnx_light_cpu_benchmark.py
+++ b/scripts/tests/test_record_onnx_light_cpu_benchmark.py
@@ -141,6 +141,35 @@ class TestPayload(unittest.TestCase):
         self.assertEqual(payload["simd_name"], "AVX2")
         self.assertEqual(payload["date"], "2026-01-02T00:00:00Z")
 
+    def test_run_tests_uses_global_backend_phases(self):
+        model = types.SimpleNamespace(
+            graph=types.SimpleNamespace(
+                node=[types.SimpleNamespace(op_type="Abs", domain="")]
+            )
+        )
+        tests = [
+            {
+                "name": f"test_cpu_abs_{index}_benchmark",
+                "model": model,
+                "data_sets": [
+                    (([types.SimpleNamespace(dtype="float32", shape=(1,))]), [])
+                ],
+            }
+            for index in range(2)
+        ]
+        calls = []
+
+        def run(model, data_sets, backend, n_warmup, n_measure):
+            calls.append(backend)
+            return {"success": True, "avg_ms": 1.0}
+
+        rcb.run_tests(tests, run=run)
+
+        self.assertEqual(
+            calls,
+            ["onnx_light_cpu", "onnx_light_cpu", "onnxruntime", "onnxruntime"],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- run all plain onnx-light cases, then all onnx-light-cpu cases, then all ONNX Runtime cases
- release sessions between global phases while preserving each runtime's default spin policy
- stop repeated measurements at the repeat limit or two seconds of cumulative measured execution
- apply the same phase ordering to the onnx-light-cpu benchmark dashboard recorder
- add a shared benchmark methodology page linked from both dashboards

## Validation
- `python -m pytest -q scripts/tests/test_record_onnx_light_benchmark.py scripts/tests/test_record_onnx_light_cpu_benchmark.py scripts/tests/test_benchmark_dashboard.py scripts/tests/test_examples_benchmark_dashboard.py` (135 passed, 4 subtests passed)
- `ruff check scripts/record_onnx_light_benchmark.py scripts/record_onnx_light_cpu_benchmark.py scripts/tests/test_record_onnx_light_benchmark.py scripts/tests/test_record_onnx_light_cpu_benchmark.py scripts/tests/test_benchmark_dashboard.py scripts/tests/test_examples_benchmark_dashboard.py --select E9,F --quiet`
- `black .` completed; generated documentation reformatting was discarded
- repository-wide `ruff check .` reports 1,454 pre-existing violations
- benchmark execution delegated to GitHub Actions
