### PR TITLE
Scale benchmark repetitions by CPU count

### DIFF
--- a/dashboard/benchmark-methodology.html
+++ b/dashboard/benchmark-methodology.html
@@ -49,8 +49,9 @@ code {
 </p>
 <h2>Sampling</h2>
 <p>
-  Warm-up calls are untimed. A measurement stops when its requested repetition
-  count is reached or after two seconds of cumulative measured execution,
+  Warm-up calls are untimed. The benchmark requests two warm-up repetitions and
+  ten measured repetitions per logical CPU. Each phase stops when its requested
+  repetition count is reached or after one second of cumulative execution,
   whichever comes first. A call already in progress finishes normally. The
   dashboard records the actual sample count and reports the existing trimmed
   mean or median defined by each recorder.

--- a/dashboard/onnx-light-cpu/cpu-benchmark.html
+++ b/dashboard/onnx-light-cpu/cpu-benchmark.html
@@ -191,10 +191,11 @@ table.benchmark tbody tr:hover { background: rgba(56, 139, 253, 0.08); }
     example exercises an operator over a range of inputs and shows
     <code>numpy</code> as a baseline; each big model is a single larger graph
     from onnx&#8209;light's benchmark corpus. Backends run in separate global
-    phases with their default spin policies. Every measurement runs
-    <strong id="nWarmupLabel">3</strong> warm-up calls (not timed) and uses up
-    to <strong id="nMeasureLabel">10</strong> timed repetitions, stopping after
-    two seconds of cumulative measured execution.
+    phases with their default spin policies. Every measurement runs up to
+    <strong id="nWarmupLabel">CPU-scaled</strong> warm-up calls (not timed) and
+    up to <strong id="nMeasureLabel">CPU-scaled</strong> timed repetitions.
+    Each phase stops after <strong id="maxRepeatTimeLabel">1</strong> second of
+    cumulative execution.
     <strong>speed-up (cpu)</strong> = <code>onnxruntime</code> /
     <code>onnx&#8209;light&#8209;cpu</code>: values&nbsp;&gt;&nbsp;1 mean
     onnx&#8209;light&#8209;cpu is faster than onnxruntime. Select an operator
@@ -307,6 +308,10 @@ function renderMeta(payload) {
   }
   if (payload.n_measure !== undefined) {
     document.getElementById("nMeasureLabel").textContent = payload.n_measure;
+  }
+  if (payload.max_repeat_time_s !== undefined) {
+    document.getElementById("maxRepeatTimeLabel").textContent =
+      payload.max_repeat_time_s;
   }
   const simd = document.getElementById("metaSimd");
   if (payload.simd_name) {

--- a/dashboard/onnx-light/benchmark.html
+++ b/dashboard/onnx-light/benchmark.html
@@ -271,9 +271,11 @@ table.benchmark tr.graph-row > td {
     dispatch table (<code>onnx_light.reference.ReferenceEvaluator</code>)
     on every ONNX backend node test.
     Backends run in separate global phases with their default spin policies.
-    Each test runs <strong id="nWarmupLabel">3</strong> warm-up iterations
-    (not timed) and up to <strong id="nMeasureLabel">10</strong> timed
-    iterations, stopping after two seconds of cumulative measured execution;
+    Each test runs up to <strong id="nWarmupLabel">CPU-scaled</strong> warm-up
+    iterations (not timed) and up to
+    <strong id="nMeasureLabel">CPU-scaled</strong> timed iterations. Each phase
+    stops after <strong id="maxRepeatTimeLabel">1</strong> second of cumulative
+    execution;
     the <em>average</em> time per dataset is reported (a trimmed mean that
     excludes the fastest and slowest timed iterations; hover a cell for the
     raw min/max).
@@ -433,6 +435,9 @@ function renderMeta(payload) {
     document.getElementById("nWarmupLabel").textContent = String(payload.n_warmup);
   if (payload.n_measure !== undefined)
     document.getElementById("nMeasureLabel").textContent = String(payload.n_measure);
+  if (payload.max_repeat_time_s !== undefined)
+    document.getElementById("maxRepeatTimeLabel").textContent =
+      String(payload.max_repeat_time_s);
 
   const versions = payload.versions || {};
   const verEl = document.getElementById("metaVersions");
@@ -450,9 +455,14 @@ function renderMeta(payload) {
   }
 
   const proto = document.getElementById("metaProtocol");
-  proto.textContent =
-    " Protocol: " + (payload.n_warmup || 3) + " warm-up + " +
-    (payload.n_measure || 10) + " timed iteration(s) per test.";
+  if (payload.n_warmup !== undefined && payload.n_measure !== undefined) {
+    proto.textContent =
+      " Protocol: up to " + payload.n_warmup + " warm-up + " +
+      payload.n_measure + " timed iteration(s) per test" +
+      (payload.max_repeat_time_s === undefined
+        ? "."
+        : ", each capped at " + payload.max_repeat_time_s + " second(s).");
+  }
 
   renderSummaryCards(payload.summary || {}, payload.tests || [], payload.n_warmup, payload.n_measure);
   renderOperatorWeights(payload.summary || {}, payload.tests || []);

--- a/scripts/record_onnx_light_benchmark.py
+++ b/scripts/record_onnx_light_benchmark.py
@@ -28,9 +28,10 @@ default worker-spin policy without perturbing another runtime's measurements.
 For each backend and test the measurement protocol is:
 
 1. Load / compile the model once (not timed).
-2. Run :data:`N_WARMUP` iterations to prime the JIT / kernel cache.
-3. Run up to :data:`N_MEASURE` iterations, stopping after two seconds of
-   cumulative measured execution, and record the wall-clock time of each.
+2. Run up to :data:`N_WARMUP` iterations to prime the JIT / kernel cache,
+   stopping after :data:`MAX_REPEAT_TIME_S` seconds of cumulative execution.
+3. Run up to :data:`N_MEASURE` iterations, also stopping after
+   :data:`MAX_REPEAT_TIME_S` seconds, and record the wall-clock time of each.
 4. Report the per-backend **average** execution time
    (in milliseconds), computed as a trimmed mean that discards the fastest
    and slowest timed iterations, along with the raw ``min``/``max`` samples,
@@ -66,6 +67,7 @@ Usage::
 
     python scripts/record_onnx_light_benchmark.py [--cache-dir DIR]
         [--kind node] [--limit N] [--n-warmup N] [--n-measure N]
+        [--max-repeat-time SECONDS]
 """
 
 from __future__ import annotations
@@ -104,13 +106,15 @@ BACKEND_PACKAGE: Dict[str, str] = {
     "onnx_light_cpu": "onnx_light_cpu",
 }
 
+CPU_COUNT: int = os.cpu_count() or 1
+
 #: Default number of warm-up iterations (not timed) run before measurement.
-N_WARMUP: int = 3
+N_WARMUP: int = 2 * CPU_COUNT
 
 #: Default number of timed iterations used to compute the average time.
-N_MEASURE: int = 10
+N_MEASURE: int = 10 * CPU_COUNT
 
-MAX_MEASURE_DURATION_S: float = 2.0
+MAX_REPEAT_TIME_S: float = 1.0
 
 DEFAULT_KIND: str = "node"
 
@@ -739,7 +743,7 @@ def run_benchmark(
     backend: str,
     n_warmup: int = N_WARMUP,
     n_measure: int = N_MEASURE,
-    max_measure_duration_s: float = MAX_MEASURE_DURATION_S,
+    max_repeat_time_s: float = MAX_REPEAT_TIME_S,
 ) -> Dict[str, Any]:
     """Run a benchmark for ``backend`` on ``model`` / ``data_sets``.
 
@@ -782,7 +786,10 @@ def run_benchmark(
         }
 
     # --- Warm-up iterations (not timed) -------------------------------------
+    warmup_count = 0
+    warmup_elapsed_s = 0.0
     for _ in range(n_warmup):
+        t0 = time.perf_counter()
         for inputs, _ in data_sets:
             try:
                 runner(inputs)
@@ -791,9 +798,13 @@ def run_benchmark(
                     "success": False,
                     "error": _stringify_error(exc),
                     "error_step": "warmup",
-                    "n_warmup": 0,
+                    "n_warmup": warmup_count,
                     "n_measure": 0,
                 }
+        warmup_count += 1
+        warmup_elapsed_s += time.perf_counter() - t0
+        if warmup_elapsed_s >= max_repeat_time_s:
+            break
 
     # --- Timed measurement iterations ---------------------------------------
     times_ms: List[float] = []
@@ -808,14 +819,14 @@ def run_benchmark(
                     "success": False,
                     "error": _stringify_error(exc),
                     "error_step": "measure",
-                    "n_warmup": n_warmup,
+                    "n_warmup": warmup_count,
                     "n_measure": len(times_ms),
                 }
         elapsed_s = time.perf_counter() - t0
         elapsed_ms = elapsed_s * 1_000
         times_ms.append(elapsed_ms)
         total_elapsed_s += elapsed_s
-        if total_elapsed_s >= max_measure_duration_s:
+        if total_elapsed_s >= max_repeat_time_s:
             break
 
     if not times_ms:
@@ -823,7 +834,7 @@ def run_benchmark(
             "success": False,
             "error": "no timing samples collected",
             "error_step": "measure",
-            "n_warmup": n_warmup,
+            "n_warmup": warmup_count,
             "n_measure": 0,
         }
 
@@ -844,7 +855,7 @@ def run_benchmark(
         "avg_ms": round(avg_ms, 6),
         "min_ms": round(sorted_ms[0], 6),
         "max_ms": round(sorted_ms[-1], 6),
-        "n_warmup": n_warmup,
+        "n_warmup": warmup_count,
         "n_measure": len(times_ms),
     }
 
@@ -1135,6 +1146,7 @@ def build_payload(
     limit: Optional[int] = None,
     n_warmup: int = N_WARMUP,
     n_measure: int = N_MEASURE,
+    max_repeat_time_s: float = MAX_REPEAT_TIME_S,
     discover: Callable[[str], List[Dict[str, Any]]] = discover_node_tests,
     run: Callable[..., Dict[str, Any]] = run_benchmark,
     versions: Optional[Callable[[], Dict[str, str]]] = None,
@@ -1161,6 +1173,7 @@ def build_payload(
                 backend,
                 n_warmup=n_warmup,
                 n_measure=n_measure,
+                max_repeat_time_s=max_repeat_time_s,
             )
         except Exception as exc:  # noqa: BLE001
             _log(
@@ -1273,6 +1286,7 @@ def build_payload(
         "kind": kind,
         "n_warmup": n_warmup,
         "n_measure": n_measure,
+        "max_repeat_time_s": max_repeat_time_s,
         "versions": version_map,
         "summary": summary,
         "tests": rows,
@@ -1339,6 +1353,15 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         default=N_MEASURE,
         help=f"Number of timed iterations per test (default: {N_MEASURE}).",
     )
+    parser.add_argument(
+        "--max-repeat-time",
+        type=float,
+        default=MAX_REPEAT_TIME_S,
+        help=(
+            "Maximum cumulative time in seconds for each warm-up and "
+            f"measurement phase (default: {MAX_REPEAT_TIME_S})."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -1351,6 +1374,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             limit=args.limit,
             n_warmup=args.n_warmup,
             n_measure=args.n_measure,
+            max_repeat_time_s=args.max_repeat_time,
         )
     except Exception as exc:  # noqa: BLE001
         _log(f"ERROR: failed to record benchmark: {exc}")

--- a/scripts/record_onnx_light_cpu_benchmark.py
+++ b/scripts/record_onnx_light_cpu_benchmark.py
@@ -22,8 +22,9 @@ from typing import Any
 import record_onnx_light_benchmark as rlb
 
 BENCHMARK_BACKENDS = ("onnx_light_cpu", "onnxruntime")
-N_WARMUP = 3
-N_MEASURE = 10
+N_WARMUP = rlb.N_WARMUP
+N_MEASURE = rlb.N_MEASURE
+MAX_REPEAT_TIME_S = rlb.MAX_REPEAT_TIME_S
 _SIMD_NAMES = {0: "scalar", 1: "SSE2", 2: "AVX", 3: "AVX2", 4: "AVX-512"}
 
 
@@ -163,6 +164,7 @@ def run_tests(
     tests: list[dict[str, Any]],
     n_warmup: int = N_WARMUP,
     n_measure: int = N_MEASURE,
+    max_repeat_time_s: float = MAX_REPEAT_TIME_S,
     run: Callable[..., dict[str, Any]] = rlb.run_benchmark,
 ) -> list[dict[str, Any]]:
     """Benchmark the supplied onnx-light-cpu cases."""
@@ -175,6 +177,7 @@ def run_tests(
                 "onnx_light_cpu",
                 n_warmup=n_warmup,
                 n_measure=n_measure,
+                max_repeat_time_s=max_repeat_time_s,
             )
         )
     gc.collect()
@@ -188,6 +191,7 @@ def run_tests(
                 "onnxruntime",
                 n_warmup=n_warmup,
                 n_measure=n_measure,
+                max_repeat_time_s=max_repeat_time_s,
             )
         )
 
@@ -214,6 +218,7 @@ def build_payload(
     limit: int | None = None,
     n_warmup: int = N_WARMUP,
     n_measure: int = N_MEASURE,
+    max_repeat_time_s: float = MAX_REPEAT_TIME_S,
     discover: Callable[[str], list[dict[str, Any]]] = discover_benchmark_tests,
     run: Callable[..., list[dict[str, Any]]] = run_tests,
     versions: Callable[[], dict[str, str]] = collect_versions,
@@ -231,10 +236,16 @@ def build_payload(
         "date": timestamp.astimezone(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "n_warmup": n_warmup,
         "n_measure": n_measure,
+        "max_repeat_time_s": max_repeat_time_s,
         "versions": versions(),
         "simd_level": level,
         "simd_name": _SIMD_NAMES.get(level, str(level)),
-        "examples": run(tests, n_warmup=n_warmup, n_measure=n_measure),
+        "examples": run(
+            tests,
+            n_warmup=n_warmup,
+            n_measure=n_measure,
+            max_repeat_time_s=max_repeat_time_s,
+        ),
     }
 
 
@@ -252,6 +263,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--limit", type=int)
     parser.add_argument("--n-warmup", type=int, default=N_WARMUP)
     parser.add_argument("--n-measure", type=int, default=N_MEASURE)
+    parser.add_argument("--max-repeat-time", type=float, default=MAX_REPEAT_TIME_S)
     return parser.parse_args(argv)
 
 
@@ -262,6 +274,7 @@ def main(argv: list[str] | None = None) -> int:
         limit=args.limit,
         n_warmup=args.n_warmup,
         n_measure=args.n_measure,
+        max_repeat_time_s=args.max_repeat_time,
     )
     path = os.path.join(args.cache_dir, "onnx-light-cpu", "examples_benchmark.json")
     write_payload(path, payload)

--- a/scripts/tests/test_benchmark_dashboard.py
+++ b/scripts/tests/test_benchmark_dashboard.py
@@ -39,7 +39,14 @@ class TestBenchmarkDashboard(unittest.TestCase):
         self.assertIn('href="../benchmark-methodology.html"', text)
         methodology = _read(METHODOLOGY)
         self.assertIn("separate competing runtimes into global phases", methodology)
-        self.assertIn("two seconds of cumulative measured execution", methodology)
+        self.assertIn("two warm-up repetitions", methodology)
+        self.assertIn("ten measured repetitions per logical CPU", methodology)
+        self.assertIn("after one second of cumulative execution", methodology)
+
+    def test_page_shows_repeat_time_limit(self):
+        text = _read(PAGE)
+        self.assertIn('id="maxRepeatTimeLabel"', text)
+        self.assertIn("payload.max_repeat_time_s", text)
 
     def test_input_type_column_present(self):
         text = _read(PAGE)

--- a/scripts/tests/test_examples_benchmark_dashboard.py
+++ b/scripts/tests/test_examples_benchmark_dashboard.py
@@ -254,6 +254,11 @@ class TestScriptCLI(unittest.TestCase):
         for name in ("build_payload", "write_payload", "main", "parse_args"):
             self.assertTrue(hasattr(module, name), f"missing {name}")
 
+    def test_page_shows_repeat_time_limit(self):
+        text = _read(PAGE)
+        self.assertIn('id="maxRepeatTimeLabel"', text)
+        self.assertIn("payload.max_repeat_time_s", text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_record_onnx_light_benchmark.py
+++ b/scripts/tests/test_record_onnx_light_benchmark.py
@@ -458,9 +458,40 @@ class TestRunBenchmark(unittest.TestCase):
                 object(),
                 [([np.ones((1,))], [np.zeros((1,))])],
                 "onnxruntime",
-                n_warmup=1,
+                n_warmup=0,
                 n_measure=5,
-                max_measure_duration_s=1.0,
+                max_repeat_time_s=1.0,
+            )
+        finally:
+            rlb.time.perf_counter = saved_pc
+            if saved is None:
+                del rlb._RUNNER_FACTORIES["onnxruntime"]
+            else:
+                rlb._RUNNER_FACTORIES["onnxruntime"] = saved
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["n_warmup"], 0)
+        self.assertEqual(result["n_measure"], 1)
+        self.assertEqual(result["avg_ms"], 1100.0)
+
+    def test_warmup_stops_after_cumulative_duration(self):
+        ticks = iter((0.0, 1.1, 2.0, 2.1))
+
+        def _dummy_factory(model):
+            return lambda inputs: [np.zeros((1,))]
+
+        saved = rlb._RUNNER_FACTORIES.get("onnxruntime")
+        saved_pc = rlb.time.perf_counter
+        try:
+            rlb._RUNNER_FACTORIES["onnxruntime"] = _dummy_factory
+            rlb.time.perf_counter = lambda: next(ticks)
+            result = rlb.run_benchmark(
+                object(),
+                [([np.ones((1,))], [np.zeros((1,))])],
+                "onnxruntime",
+                n_warmup=5,
+                n_measure=1,
+                max_repeat_time_s=1.0,
             )
         finally:
             rlb.time.perf_counter = saved_pc
@@ -472,7 +503,6 @@ class TestRunBenchmark(unittest.TestCase):
         self.assertTrue(result["success"])
         self.assertEqual(result["n_warmup"], 1)
         self.assertEqual(result["n_measure"], 1)
-        self.assertEqual(result["avg_ms"], 1100.0)
 
 
 class TestSymbolicCost(unittest.TestCase):
@@ -714,8 +744,15 @@ class TestBuildPayload(unittest.TestCase):
 
         call_log = []
 
-        def _run(model, data_sets, backend, n_warmup, n_measure):
-            call_log.append((backend, n_warmup, n_measure))
+        def _run(
+            model,
+            data_sets,
+            backend,
+            n_warmup,
+            n_measure,
+            max_repeat_time_s,
+        ):
+            call_log.append((backend, n_warmup, n_measure, max_repeat_time_s))
             return {
                 "success": True,
                 "error": "",
@@ -729,6 +766,7 @@ class TestBuildPayload(unittest.TestCase):
             kind="node",
             n_warmup=2,
             n_measure=7,
+            max_repeat_time_s=0.5,
             discover=_discover,
             run=_run,
             versions=lambda: {"onnxruntime": "1.0", "onnx_light": "0.1"},
@@ -738,6 +776,7 @@ class TestBuildPayload(unittest.TestCase):
         self.assertIn("kind", payload)
         self.assertEqual(payload["n_warmup"], 2)
         self.assertEqual(payload["n_measure"], 7)
+        self.assertEqual(payload["max_repeat_time_s"], 0.5)
         self.assertIn("summary", payload)
         self.assertIn("tests", payload)
         self.assertEqual(len(payload["tests"]), 2)
@@ -745,17 +784,18 @@ class TestBuildPayload(unittest.TestCase):
         # Each test should have been run against both BENCHMARK_BACKENDS.
         for backend in rlb.BENCHMARK_BACKENDS:
             self.assertGreater(
-                sum(1 for b, _, _ in call_log if b == backend),
+                sum(1 for b, _, _, _ in call_log if b == backend),
                 0,
                 msg=f"{backend} was never called",
             )
 
         # Check that both warm-up and measure counts are forwarded.
-        for backend, nw, nm in call_log:
+        for backend, nw, nm, max_repeat_time_s in call_log:
             self.assertEqual(nw, 2)
             self.assertEqual(nm, 7)
+            self.assertEqual(max_repeat_time_s, 0.5)
         self.assertEqual(
-            [backend for backend, _, _ in call_log],
+            [backend for backend, _, _, _ in call_log],
             [backend for backend in rlb.BENCHMARK_EXECUTION_ORDER for _ in range(2)],
         )
 
@@ -815,7 +855,14 @@ class TestBuildPayload(unittest.TestCase):
                 for i in range(20)
             ]
 
-        def _run(model, data_sets, backend, n_warmup, n_measure):
+        def _run(
+            model,
+            data_sets,
+            backend,
+            n_warmup,
+            n_measure,
+            max_repeat_time_s,
+        ):
             return {
                 "success": False,
                 "error": "no data",
@@ -883,12 +930,27 @@ class TestParseArgs(unittest.TestCase):
         self.assertEqual(args.kind, rlb.DEFAULT_KIND)
         self.assertEqual(args.n_warmup, rlb.N_WARMUP)
         self.assertEqual(args.n_measure, rlb.N_MEASURE)
+        self.assertEqual(args.max_repeat_time, rlb.MAX_REPEAT_TIME_S)
+        self.assertEqual(rlb.N_WARMUP, 2 * (os.cpu_count() or 1))
+        self.assertEqual(rlb.N_MEASURE, 10 * (os.cpu_count() or 1))
         self.assertIsNone(args.limit)
 
     def test_override(self):
-        args = rlb.parse_args(["--n-warmup", "5", "--n-measure", "20", "--limit", "10"])
+        args = rlb.parse_args(
+            [
+                "--n-warmup",
+                "5",
+                "--n-measure",
+                "20",
+                "--max-repeat-time",
+                "0.25",
+                "--limit",
+                "10",
+            ]
+        )
         self.assertEqual(args.n_warmup, 5)
         self.assertEqual(args.n_measure, 20)
+        self.assertEqual(args.max_repeat_time, 0.25)
         self.assertEqual(args.limit, 10)
 
 

--- a/scripts/tests/test_record_onnx_light_cpu_benchmark.py
+++ b/scripts/tests/test_record_onnx_light_cpu_benchmark.py
@@ -117,8 +117,9 @@ class TestPayload(unittest.TestCase):
     def test_payload_uses_discovered_tests(self):
         calls = {}
 
-        def run(tests, n_warmup, n_measure):
+        def run(tests, n_warmup, n_measure, max_repeat_time_s):
             calls["tests"] = tests
+            calls["max_repeat_time_s"] = max_repeat_time_s
             return []
 
         cpu = types.ModuleType("onnx_light_cpu.onnx_py._cpukernels")
@@ -138,6 +139,7 @@ class TestPayload(unittest.TestCase):
             else:
                 sys.modules[cpu.__name__] = original
         self.assertEqual(calls["tests"], [{"name": "test_cpu_abs_benchmark"}])
+        self.assertEqual(calls["max_repeat_time_s"], rcb.MAX_REPEAT_TIME_S)
         self.assertEqual(payload["simd_name"], "AVX2")
         self.assertEqual(payload["date"], "2026-01-02T00:00:00Z")
 
@@ -159,15 +161,27 @@ class TestPayload(unittest.TestCase):
         ]
         calls = []
 
-        def run(model, data_sets, backend, n_warmup, n_measure):
-            calls.append(backend)
+        def run(
+            model,
+            data_sets,
+            backend,
+            n_warmup,
+            n_measure,
+            max_repeat_time_s,
+        ):
+            calls.append((backend, max_repeat_time_s))
             return {"success": True, "avg_ms": 1.0}
 
         rcb.run_tests(tests, run=run)
 
         self.assertEqual(
             calls,
-            ["onnx_light_cpu", "onnx_light_cpu", "onnxruntime", "onnxruntime"],
+            [
+                ("onnx_light_cpu", rcb.MAX_REPEAT_TIME_S),
+                ("onnx_light_cpu", rcb.MAX_REPEAT_TIME_S),
+                ("onnxruntime", rcb.MAX_REPEAT_TIME_S),
+                ("onnxruntime", rcb.MAX_REPEAT_TIME_S),
+            ],
         )
 
 


### PR DESCRIPTION
## Summary
- use `2 * os.cpu_count()` warm-up iterations and `10 * os.cpu_count()` measured iterations
- cap both warm-up and measurement phases at one second with `--max-repeat-time`
- run onnx-light / onnx-light-cpu phases before onnxruntime and document the protocol on both dashboards

## Tests
- `python -m unittest discover -s scripts/tests` (619 tests)
- `python -m unittest discover -s scripts/tests -p 'test_*benchmark*.py'` (139 tests)