### PR TITLE
Pass machine metadata in ONNX docs workflow

### DIFF
--- a/.github/workflows/build_onnx_light_docs.yml
+++ b/.github/workflows/build_onnx_light_docs.yml
@@ -161,11 +161,13 @@ jobs:
 
       - name: Record plot_onnx_time history
         run: |
+          machine="${{ runner.os }} ${{ runner.arch }} / $(lscpu | sed -n 's/^Model name:[[:space:]]*//p' | head -1)"
           python site/scripts/record_onnx_time.py \
             site/docs/onnx-light/auto_examples_proto/plot_onnx_time.html \
             --output site/cache_data/onnx-light/onnx_time.csv \
             --commit "$(git -C onnx-light rev-parse HEAD)" \
-            --run-id "${{ github.run_id }}"
+            --run-id "${{ github.run_id }}" \
+            --machine "${machine}"
 
       - name: Commit and push updated documentation
         working-directory: site

--- a/scripts/tests/test_onnx_time_dashboard.py
+++ b/scripts/tests/test_onnx_time_dashboard.py
@@ -8,6 +8,7 @@ import unittest
 ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 PAGE = os.path.join(ROOT, "dashboard", "onnx-light", "onnx-time.html")
 WORKFLOW = os.path.join(ROOT, ".github", "workflows", "record_onnx_time.yml")
+DOC_WORKFLOW = os.path.join(ROOT, ".github", "workflows", "build_onnx_light_docs.yml")
 DATA = os.path.join(ROOT, "cache_data", "onnx-light", "onnx_time.csv")
 
 
@@ -67,8 +68,15 @@ class TestOnnxTimeDashboard(unittest.TestCase):
         self.assertIn("python scripts/record_onnx_time.py", text)
         self.assertIn("--output cache_data/onnx-light/onnx_time.csv", text)
         self.assertIn("--machine", text)
-        self.assertIn('git -C onnx-light rev-parse HEAD', text)
-        self.assertIn('git add cache_data/onnx-light/onnx_time.csv', text)
+        self.assertIn("git -C onnx-light rev-parse HEAD", text)
+        self.assertIn("git add cache_data/onnx-light/onnx_time.csv", text)
+
+    def test_documentation_workflow_records_machine(self):
+        with open(DOC_WORKFLOW, encoding="utf-8") as stream:
+            text = stream.read()
+        self.assertIn("python site/scripts/record_onnx_time.py", text)
+        self.assertIn('machine="${{ runner.os }} ${{ runner.arch }} / $(lscpu', text)
+        self.assertIn('--machine "${machine}"', text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- pass the runner OS, architecture, and CPU model to `record_onnx_time.py` from the documentation workflow
- add regression coverage for the documentation workflow call site

## Diagnosis

[Job 98444562074](https://github.com/xadupre/xadupre.github.io/actions/runs/33050505218/job/98444562074) checked out `xadupre/onnx-light`, but failed in `site/scripts/record_onnx_time.py`, which is owned by this repository. The workflow omitted the then-required `--machine` argument and argparse exited with code 2. PR #800 subsequently added a CLI fallback; this change fixes the workflow call site too and records the more useful CPU-specific label already used by the dedicated timing workflow.

## Validation

- `python -m unittest discover -s scripts/tests -p "test_*onnx_time*.py"` (9 passed)
- `ruff check scripts/tests/test_onnx_time_dashboard.py`
- `ruff format --check scripts/tests/test_onnx_time_dashboard.py`
- `black --check scripts/tests/test_onnx_time_dashboard.py`
- PyYAML parse of `.github/workflows/build_onnx_light_docs.yml`
- `git diff --check`