### PR TITLE
Fix onnx-light CPU benchmark case lookup

### DIFF
--- a/scripts/record_onnx_light_cpu_benchmark.py
+++ b/scripts/record_onnx_light_cpu_benchmark.py
@@ -64,9 +64,11 @@ def discover_benchmark_tests(kind: str = "node") -> list[dict[str, Any]]:
 
 
 def _load_benchmark_test(name: str) -> dict[str, Any]:
-    from onnx_light.onnx.backend import TestMode, get_test_case_by_name
+    from onnx_light.onnx.backend import TestMode, collect_test_cases_by_name
 
-    cases = get_test_case_by_name(name, include_big=True, mode=TestMode.BENCHMARK)
+    cases = collect_test_cases_by_name(
+        f"^{re.escape(name)}$", include_big=True, mode=TestMode.BENCHMARK
+    )
     if len(cases) != 1:
         raise RuntimeError(f"Unable to load benchmark test {name!r}.")
     case = cases[0]

--- a/scripts/tests/test_record_onnx_light_cpu_benchmark.py
+++ b/scripts/tests/test_record_onnx_light_cpu_benchmark.py
@@ -7,6 +7,7 @@ import os
 import sys
 import types
 import unittest
+from unittest.mock import patch
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.dirname(HERE))
@@ -38,6 +39,48 @@ class TestDiscovery(unittest.TestCase):
         self.assertEqual(calls, ["registered"])
         self.assertEqual([test["name"] for test in tests], ["test_cpu_abs_benchmark"])
         self.assertNotIn("model", tests[0])
+
+
+class TestLoading(unittest.TestCase):
+    def test_loads_one_benchmark_case_by_exact_name(self):
+        calls = []
+        benchmark_mode = object()
+        backend = types.ModuleType("onnx_light.onnx.backend")
+        backend.TestMode = types.SimpleNamespace(BENCHMARK=benchmark_mode)
+        backend.collect_test_cases_by_name = lambda pattern, **kwargs: (
+            calls.append((pattern, kwargs)) or [types.SimpleNamespace(model="cc-model")]
+        )
+        modules = {
+            "onnx_light": types.ModuleType("onnx_light"),
+            "onnx_light.onnx": types.ModuleType("onnx_light.onnx"),
+            "onnx_light.onnx.backend": backend,
+        }
+        with (
+            patch.dict(sys.modules, modules),
+            patch.object(
+                rcb.rlb, "_onnx_light_model_to_onnx", lambda model: f"onnx-{model}"
+            ),
+            patch.object(rcb.rlb, "_cc_data_sets_to_python", lambda case: ["data"]),
+        ):
+            loaded = rcb._load_benchmark_test("test_cpu_abs[1]_benchmark")
+
+        self.assertEqual(
+            calls,
+            [
+                (
+                    r"^test_cpu_abs\[1\]_benchmark$",
+                    {"include_big": True, "mode": benchmark_mode},
+                )
+            ],
+        )
+        self.assertEqual(
+            loaded,
+            {
+                "name": "test_cpu_abs[1]_benchmark",
+                "model": "onnx-cc-model",
+                "data_sets": ["data"],
+            },
+        )
 
 
 class TestRows(unittest.TestCase):


### PR DESCRIPTION
## Summary
- replace the removed `get_test_case_by_name` import with `collect_test_cases_by_name`
- anchor and escape the requested benchmark name to preserve exact-match behavior
- add regression coverage for the current onnx-light backend API

## Failure diagnosis
Job 98478963263 failed in `scripts/record_onnx_light_cpu_benchmark.py` because current `onnx_light.onnx.backend` no longer exports `get_test_case_by_name`. The failing code is owned by this repository; the checked-out onnx-light and onnx-light-cpu builds completed successfully.

## Validation
- `python -m unittest discover -s scripts/tests -p 'test_record_onnx_light_cpu_benchmark.py' -q` (7 tests)\n- `python -m unittest discover -s scripts/tests -q` (625 tests)\n- `ruff check` and `ruff format --check` on changed files\n- `black --check` on changed files