### PR TITLE
Shorten onnx-light-cpu benchmark sampling

### DIFF
--- a/scripts/record_onnx_light_benchmark.py
+++ b/scripts/record_onnx_light_benchmark.py
@@ -744,6 +744,7 @@ def run_benchmark(
     n_warmup: int = N_WARMUP,
     n_measure: int = N_MEASURE,
     max_repeat_time_s: float = MAX_REPEAT_TIME_S,
+    max_warmup_time_s: Optional[float] = None,
 ) -> Dict[str, Any]:
     """Run a benchmark for ``backend`` on ``model`` / ``data_sets``.
 
@@ -760,6 +761,9 @@ def run_benchmark(
     * ``n_warmup`` – number of warm-up iterations actually run.
     * ``n_measure`` – number of timed iterations actually run.
     """
+    if max_warmup_time_s is None:
+        max_warmup_time_s = max_repeat_time_s
+
     factory = _RUNNER_FACTORIES.get(backend)
     if factory is None:
         return {
@@ -803,7 +807,7 @@ def run_benchmark(
                 }
         warmup_count += 1
         warmup_elapsed_s += time.perf_counter() - t0
-        if warmup_elapsed_s >= max_repeat_time_s:
+        if warmup_elapsed_s >= max_warmup_time_s:
             break
 
     # --- Timed measurement iterations ---------------------------------------
@@ -826,7 +830,7 @@ def run_benchmark(
         elapsed_ms = elapsed_s * 1_000
         times_ms.append(elapsed_ms)
         total_elapsed_s += elapsed_s
-        if total_elapsed_s >= max_repeat_time_s:
+        if len(times_ms) >= min(3, n_measure) and total_elapsed_s >= max_repeat_time_s:
             break
 
     if not times_ms:

--- a/scripts/record_onnx_light_cpu_benchmark.py
+++ b/scripts/record_onnx_light_cpu_benchmark.py
@@ -22,9 +22,10 @@ from typing import Any
 import record_onnx_light_benchmark as rlb
 
 BENCHMARK_BACKENDS = ("onnx_light_cpu", "onnxruntime")
-N_WARMUP = rlb.N_WARMUP
+N_WARMUP = 2
 N_MEASURE = rlb.N_MEASURE
-MAX_REPEAT_TIME_S = rlb.MAX_REPEAT_TIME_S
+MAX_WARMUP_TIME_S = 0.05
+MAX_REPEAT_TIME_S = 0.2
 _SIMD_NAMES = {0: "scalar", 1: "SSE2", 2: "AVX", 3: "AVX2", 4: "AVX-512"}
 
 
@@ -188,6 +189,7 @@ def run_tests(
     tests: list[dict[str, Any]],
     n_warmup: int = N_WARMUP,
     n_measure: int = N_MEASURE,
+    max_warmup_time_s: float = MAX_WARMUP_TIME_S,
     max_repeat_time_s: float = MAX_REPEAT_TIME_S,
     run: Callable[..., dict[str, Any]] = rlb.run_benchmark,
     load: Callable[[str], dict[str, Any]] = _load_benchmark_test,
@@ -206,6 +208,7 @@ def run_tests(
                 "onnx_light_cpu",
                 n_warmup=n_warmup,
                 n_measure=n_measure,
+                max_warmup_time_s=max_warmup_time_s,
                 max_repeat_time_s=max_repeat_time_s,
             )
         )
@@ -232,6 +235,7 @@ def run_tests(
                 "onnxruntime",
                 n_warmup=n_warmup,
                 n_measure=n_measure,
+                max_warmup_time_s=max_warmup_time_s,
                 max_repeat_time_s=max_repeat_time_s,
             )
         )
@@ -259,6 +263,7 @@ def build_payload(
     limit: int | None = None,
     n_warmup: int = N_WARMUP,
     n_measure: int = N_MEASURE,
+    max_warmup_time_s: float = MAX_WARMUP_TIME_S,
     max_repeat_time_s: float = MAX_REPEAT_TIME_S,
     discover: Callable[[str], list[dict[str, Any]]] = discover_benchmark_tests,
     run: Callable[..., list[dict[str, Any]]] = run_tests,
@@ -277,6 +282,7 @@ def build_payload(
         "date": timestamp.astimezone(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "n_warmup": n_warmup,
         "n_measure": n_measure,
+        "max_warmup_time_s": max_warmup_time_s,
         "max_repeat_time_s": max_repeat_time_s,
         "versions": versions(),
         "simd_level": level,
@@ -285,6 +291,7 @@ def build_payload(
             tests,
             n_warmup=n_warmup,
             n_measure=n_measure,
+            max_warmup_time_s=max_warmup_time_s,
             max_repeat_time_s=max_repeat_time_s,
         ),
     }
@@ -304,6 +311,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--limit", type=int)
     parser.add_argument("--n-warmup", type=int, default=N_WARMUP)
     parser.add_argument("--n-measure", type=int, default=N_MEASURE)
+    parser.add_argument("--max-warmup-time", type=float, default=MAX_WARMUP_TIME_S)
     parser.add_argument("--max-repeat-time", type=float, default=MAX_REPEAT_TIME_S)
     return parser.parse_args(argv)
 
@@ -315,6 +323,7 @@ def main(argv: list[str] | None = None) -> int:
         limit=args.limit,
         n_warmup=args.n_warmup,
         n_measure=args.n_measure,
+        max_warmup_time_s=args.max_warmup_time,
         max_repeat_time_s=args.max_repeat_time,
     )
     path = os.path.join(args.cache_dir, "onnx-light-cpu", "examples_benchmark.json")

--- a/scripts/tests/test_record_onnx_light_benchmark.py
+++ b/scripts/tests/test_record_onnx_light_benchmark.py
@@ -444,7 +444,7 @@ class TestRunBenchmark(unittest.TestCase):
         self.assertAlmostEqual(result["avg_ms"], 1.0, places=6)
 
     def test_measurement_stops_after_cumulative_duration(self):
-        ticks = iter((0.0, 1.1))
+        ticks = iter((0.0, 1.1, 2.0, 3.1, 4.0, 5.1))
 
         def _dummy_factory(model):
             return lambda inputs: [np.zeros((1,))]
@@ -471,7 +471,7 @@ class TestRunBenchmark(unittest.TestCase):
 
         self.assertTrue(result["success"])
         self.assertEqual(result["n_warmup"], 0)
-        self.assertEqual(result["n_measure"], 1)
+        self.assertEqual(result["n_measure"], 3)
         self.assertEqual(result["avg_ms"], 1100.0)
 
     def test_warmup_stops_after_cumulative_duration(self):
@@ -492,6 +492,37 @@ class TestRunBenchmark(unittest.TestCase):
                 n_warmup=5,
                 n_measure=1,
                 max_repeat_time_s=1.0,
+            )
+        finally:
+            rlb.time.perf_counter = saved_pc
+            if saved is None:
+                del rlb._RUNNER_FACTORIES["onnxruntime"]
+            else:
+                rlb._RUNNER_FACTORIES["onnxruntime"] = saved
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["n_warmup"], 1)
+        self.assertEqual(result["n_measure"], 1)
+
+    def test_warmup_uses_independent_time_limit(self):
+        ticks = iter((0.0, 0.06, 1.0, 1.01))
+
+        def _dummy_factory(model):
+            return lambda inputs: [np.zeros((1,))]
+
+        saved = rlb._RUNNER_FACTORIES.get("onnxruntime")
+        saved_pc = rlb.time.perf_counter
+        try:
+            rlb._RUNNER_FACTORIES["onnxruntime"] = _dummy_factory
+            rlb.time.perf_counter = lambda: next(ticks)
+            result = rlb.run_benchmark(
+                object(),
+                [([np.ones((1,))], [np.zeros((1,))])],
+                "onnxruntime",
+                n_warmup=2,
+                n_measure=1,
+                max_warmup_time_s=0.05,
+                max_repeat_time_s=0.2,
             )
         finally:
             rlb.time.perf_counter = saved_pc

--- a/scripts/tests/test_record_onnx_light_cpu_benchmark.py
+++ b/scripts/tests/test_record_onnx_light_cpu_benchmark.py
@@ -161,8 +161,16 @@ class TestPayload(unittest.TestCase):
     def test_payload_uses_discovered_tests(self):
         calls = {}
 
-        def run(tests, n_warmup, n_measure, max_repeat_time_s):
+        def run(
+            tests,
+            n_warmup,
+            n_measure,
+            max_warmup_time_s,
+            max_repeat_time_s,
+        ):
             calls["tests"] = tests
+            calls["n_warmup"] = n_warmup
+            calls["max_warmup_time_s"] = max_warmup_time_s
             calls["max_repeat_time_s"] = max_repeat_time_s
             return []
 
@@ -183,7 +191,11 @@ class TestPayload(unittest.TestCase):
             else:
                 sys.modules[cpu.__name__] = original
         self.assertEqual(calls["tests"], [{"name": "test_cpu_abs_benchmark"}])
+        self.assertEqual(calls["n_warmup"], 2)
+        self.assertEqual(calls["max_warmup_time_s"], 0.05)
         self.assertEqual(calls["max_repeat_time_s"], rcb.MAX_REPEAT_TIME_S)
+        self.assertEqual(payload["max_warmup_time_s"], 0.05)
+        self.assertEqual(payload["max_repeat_time_s"], 0.2)
         self.assertEqual(payload["simd_name"], "AVX2")
         self.assertEqual(payload["date"], "2026-01-02T00:00:00Z")
 
@@ -211,9 +223,10 @@ class TestPayload(unittest.TestCase):
             backend,
             n_warmup,
             n_measure,
+            max_warmup_time_s,
             max_repeat_time_s,
         ):
-            calls.append((backend, max_repeat_time_s))
+            calls.append((backend, n_warmup, max_warmup_time_s, max_repeat_time_s))
             return {"success": True, "avg_ms": 1.0}
 
         with patch.object(rcb.rlb, "_log") as log:
@@ -222,10 +235,10 @@ class TestPayload(unittest.TestCase):
         self.assertEqual(
             calls,
             [
-                ("onnx_light_cpu", rcb.MAX_REPEAT_TIME_S),
-                ("onnx_light_cpu", rcb.MAX_REPEAT_TIME_S),
-                ("onnxruntime", rcb.MAX_REPEAT_TIME_S),
-                ("onnxruntime", rcb.MAX_REPEAT_TIME_S),
+                ("onnx_light_cpu", 2, 0.05, 0.2),
+                ("onnx_light_cpu", 2, 0.05, 0.2),
+                ("onnxruntime", 2, 0.05, 0.2),
+                ("onnxruntime", 2, 0.05, 0.2),
             ],
         )
         self.assertEqual(


### PR DESCRIPTION
## Summary
- run two warm-up iterations per onnx-light-cpu benchmark, stopping after the first when cumulative warm-up time exceeds 50 ms
- cap each backend measurement phase at 200 ms
- retain at least three timing samples before applying the cap so the trimmed mean remains meaningful
- persist and expose the independent warm-up time limit

## Validation
- `python -m unittest discover -s scripts/tests -p 'test_*.py'` (628 passed)
- focused benchmark recorder tests (104 passed)

The repository currently has pre-existing Ruff findings in these legacy scripts; this change does not introduce new lint findings.
