### PR TITLE
Optimize onnx-light-cpu benchmark setup

### DIFF
--- a/scripts/record_onnx_light_benchmark.py
+++ b/scripts/record_onnx_light_benchmark.py
@@ -605,7 +605,12 @@ def _make_onnx_light_runner(model) -> Callable[[List[Any]], List[Any]]:
     return _make_onnx_light_reference_runner(model)
 
 
-def _make_onnx_light_cpu_runner(model) -> Callable[[List[Any]], List[Any]]:
+def _make_onnx_light_cpu_runner(
+    model,
+    *,
+    register_kernels: bool = True,
+    verification_state: Optional[Dict[str, bool]] = None,
+) -> Callable[[List[Any]], List[Any]]:
     """Build the onnx-light runner with the ``onnx-light-cpu`` SIMD kernels active.
 
     ``onnx-light-cpu`` ships SIMD-accelerated ``Abs``/``Exp``/``Log``/``Gemm``/
@@ -644,12 +649,20 @@ def _make_onnx_light_cpu_runner(model) -> Callable[[List[Any]], List[Any]]:
     silently fell back to a built-in kernel (so onnx-light-cpu is *not* really
     used where it should be), which the process-wide
     :func:`onnx_light_cpu.used_kernel_names` record alone cannot detect.
+
+    ``register_kernels=False`` and a shared ``verification_state`` let callers
+    that run a homogeneous benchmark suite pay both process-wide setup costs
+    only once. The defaults retain the standalone per-model checks.
     """
     import onnx_light_cpu
 
     runner = _make_onnx_light_reference_runner(
-        model, register=onnx_light_cpu.register_kernels
+        model, register=onnx_light_cpu.register_kernels if register_kernels else None
     )
+
+    checked = verification_state if verification_state is not None else {"done": False}
+    if checked["done"]:
+        return runner
 
     clear_used_kernel_names = getattr(onnx_light_cpu, "clear_used_kernel_names", None)
     used_kernel_names = getattr(onnx_light_cpu, "used_kernel_names", None)
@@ -659,6 +672,7 @@ def _make_onnx_light_cpu_runner(model) -> Callable[[List[Any]], List[Any]]:
     except ImportError:
         set_kernel_usage_recording = None
     if clear_used_kernel_names is None or used_kernel_names is None:
+        checked["done"] = True
         return runner
 
     # Map of ONNX ``op_type`` -> library-qualified kernel name that
@@ -671,8 +685,6 @@ def _make_onnx_light_cpu_runner(model) -> Callable[[List[Any]], List[Any]]:
     )
     cpu_kernel_names = set(registered.values())
     overridden_op_types = set(registered)
-
-    checked = {"done": False}
 
     def _run_checked(inputs: List[Any]) -> List[Any]:
         if checked["done"]:
@@ -745,6 +757,7 @@ def run_benchmark(
     n_measure: int = N_MEASURE,
     max_repeat_time_s: float = MAX_REPEAT_TIME_S,
     max_warmup_time_s: Optional[float] = None,
+    runner_factory: Optional[Callable[[Any], Callable[[List[Any]], List[Any]]]] = None,
 ) -> Dict[str, Any]:
     """Run a benchmark for ``backend`` on ``model`` / ``data_sets``.
 
@@ -760,11 +773,14 @@ def run_benchmark(
     * ``max_ms`` – slowest timed iteration in milliseconds.
     * ``n_warmup`` – number of warm-up iterations actually run.
     * ``n_measure`` – number of timed iterations actually run.
+
+    ``runner_factory`` overrides the registered backend factory when a caller
+    needs to share process-wide setup across several benchmark invocations.
     """
     if max_warmup_time_s is None:
         max_warmup_time_s = max_repeat_time_s
 
-    factory = _RUNNER_FACTORIES.get(backend)
+    factory = runner_factory or _RUNNER_FACTORIES.get(backend)
     if factory is None:
         return {
             "success": False,

--- a/scripts/record_onnx_light_cpu_benchmark.py
+++ b/scripts/record_onnx_light_cpu_benchmark.py
@@ -126,6 +126,34 @@ def _first_input_element_count(inputs: Any) -> int:
     return 0
 
 
+def _make_cpu_suite_runner_factory() -> (
+    Callable[[Any], Callable[[list[Any]], list[Any]]]
+):
+    """Build CPU runners with one registration and one verification per suite."""
+    registration: dict[str, Any] = {"attempted": False, "error": None}
+    verification = {"done": False}
+
+    def factory(model: Any) -> Callable[[list[Any]], list[Any]]:
+        if not registration["attempted"]:
+            registration["attempted"] = True
+            try:
+                from onnx_light_cpu import register_kernels
+
+                register_kernels()
+            except Exception as exc:
+                registration["error"] = exc
+                raise
+        if registration["error"] is not None:
+            raise registration["error"]
+        return rlb._make_onnx_light_cpu_runner(
+            model,
+            register_kernels=False,
+            verification_state=verification,
+        )
+
+    return factory
+
+
 def _group_measurements(
     measurements: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
@@ -198,18 +226,26 @@ def run_tests(
     cpu_results = []
     metadata = []
     total = len(tests)
+    cpu_runner_factory = (
+        _make_cpu_suite_runner_factory() if run is rlb.run_benchmark else None
+    )
     for index, test in enumerate(tests, start=1):
         loaded = test if "model" in test else load(test["name"])
         rlb._log(f"Benchmarking {index}/{total} tests (onnx_light_cpu): {test['name']}")
+        run_kwargs = {
+            "n_warmup": n_warmup,
+            "n_measure": n_measure,
+            "max_warmup_time_s": max_warmup_time_s,
+            "max_repeat_time_s": max_repeat_time_s,
+        }
+        if cpu_runner_factory is not None:
+            run_kwargs["runner_factory"] = cpu_runner_factory
         cpu_results.append(
             run(
                 loaded["model"],
                 loaded["data_sets"],
                 "onnx_light_cpu",
-                n_warmup=n_warmup,
-                n_measure=n_measure,
-                max_warmup_time_s=max_warmup_time_s,
-                max_repeat_time_s=max_repeat_time_s,
+                **run_kwargs,
             )
         )
         first_inputs = loaded["data_sets"][0][0]

--- a/scripts/tests/test_record_onnx_light_benchmark.py
+++ b/scripts/tests/test_record_onnx_light_benchmark.py
@@ -1534,6 +1534,39 @@ class TestOnnxLightCpuRunner(unittest.TestCase):
         self.assertEqual(events["usage_recording"], [True, False])
         np.testing.assert_allclose(out[0], np.array([1.0, 2.0], dtype=np.float32))
 
+    def test_cpu_runners_can_share_completed_verification(self):
+        model, modules, events = self._install_fakes()
+        used = {"cleared": 0}
+        cpu = modules["onnx_light_cpu"]
+        cpu.clear_used_kernel_names = lambda: used.__setitem__(
+            "cleared", used["cleared"] + 1
+        )
+        cpu.used_kernel_names = lambda: ["onnx_light_cpu::Abs"]
+        cpu.registered_kernel_names = lambda: {"Abs": "onnx_light_cpu::Abs"}
+        verification = {"done": False}
+
+        saved = {name: sys.modules.get(name) for name in modules}
+        try:
+            sys.modules.update(modules)
+            first = rlb._make_onnx_light_cpu_runner(
+                model, register_kernels=False, verification_state=verification
+            )
+            first([np.array([-1.0], dtype=np.float32)])
+            second = rlb._make_onnx_light_cpu_runner(
+                model, register_kernels=False, verification_state=verification
+            )
+            second([np.array([-2.0], dtype=np.float32)])
+        finally:
+            for name, mod in saved.items():
+                if mod is None:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = mod
+
+        self.assertEqual(events["registered"], 0)
+        self.assertEqual(used["cleared"], 1)
+        self.assertEqual(events["usage_recording"], [True, False])
+
     def test_cpu_runner_registers_globally_before_evaluator(self):
         """The public API registers CPU kernels globally before construction."""
         model, modules, events = self._install_fakes()

--- a/scripts/tests/test_record_onnx_light_cpu_benchmark.py
+++ b/scripts/tests/test_record_onnx_light_cpu_benchmark.py
@@ -282,6 +282,34 @@ class TestPayload(unittest.TestCase):
             ["onnx_light_cpu", "onnx_light_cpu", "onnxruntime", "onnxruntime"],
         )
 
+    def test_cpu_suite_registers_and_verifies_only_once(self):
+        registered = []
+        verification_states = []
+        cpu = types.ModuleType("onnx_light_cpu")
+        cpu.register_kernels = lambda: registered.append(True)
+
+        def make_runner(model, *, register_kernels, verification_state):
+            self.assertFalse(register_kernels)
+            verification_states.append(verification_state)
+
+            def runner(inputs):
+                verification_state["done"] = True
+                return inputs
+
+            return runner
+
+        with (
+            patch.dict(sys.modules, {"onnx_light_cpu": cpu}),
+            patch.object(rcb.rlb, "_make_onnx_light_cpu_runner", make_runner),
+        ):
+            factory = rcb._make_cpu_suite_runner_factory()
+            factory("model-1")([])
+            factory("model-2")([])
+
+        self.assertEqual(registered, [True])
+        self.assertIs(verification_states[0], verification_states[1])
+        self.assertTrue(verification_states[0]["done"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- register onnx-light-cpu kernels once for the complete benchmark suite
- share kernel verification state so usage recording runs only once
- keep standalone `run_benchmark` calls strict by default

## Validation

- `python -m unittest discover -s scripts/tests -p 'test_record_onnx*benchmark.py' --quiet` (106 tests)\n- deterministic `cProfile` run confirms one suite state and shared runner factories; tests assert one registration and one usage-recording cycle\n\nA native profile was attempted after rebuilding `_cpuregister`, but the local neighboring checkouts currently have an ABI mismatch (`undefined symbol` in `liblib_onnx_light_cpu.so`).