### PR TITLE
Increase benchmark workflow timeout to 4 hours

### DIFF
--- a/.github/workflows/record_onnx_light_cpu_examples_benchmark.yml
+++ b/.github/workflows/record_onnx_light_cpu_examples_benchmark.yml
@@ -26,7 +26,7 @@ jobs:
   record:
     if: github.event_name == 'schedule' || github.actor == github.repository_owner || github.actor == 'github-actions[bot]'
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 240
     steps:
       - name: Checkout xadupre.github.io
         uses: actions/checkout@v6

--- a/scripts/tests/test_examples_benchmark_dashboard.py
+++ b/scripts/tests/test_examples_benchmark_dashboard.py
@@ -231,7 +231,7 @@ class TestWorkflow(unittest.TestCase):
     def test_workflow_builds_from_source_and_runs_script(self):
         text = _read(WORKFLOW)
         self.assertIn("name: DATA onnx-light-cpu benchmark", text)
-        self.assertIn("timeout-minutes: 120", text)
+        self.assertIn("timeout-minutes: 240", text)
         # Both dependencies are built from source, as required by the issue.
         self.assertIn("repository: xadupre/onnx-light", text)
         self.assertIn("repository: xadupre/onnx-light-cpu", text)


### PR DESCRIPTION
## Summary

Increase the DATA onnx-light-cpu benchmark job timeout from 120 to 240 minutes.

The benchmark step in run https://github.com/xadupre/xadupre.github.io/actions/runs/33110997198/job/98653474940 was cancelled when the existing two-hour job limit was reached.