### PR TITLE
Add ONNX Runtime PR activity dashboard

### DIFF
--- a/.github/workflows/record_onnxruntime_pr_activity.yml
+++ b/.github/workflows/record_onnxruntime_pr_activity.yml
@@ -1,0 +1,73 @@
+name: DATA onnxruntime PR activity
+
+# Records a weekly snapshot of open and recently merged pull requests in
+# microsoft/onnxruntime for dashboard/onnxruntime/pr-activity.html.
+
+on:
+  schedule:
+    - cron: "53 4 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  record:
+    if: github.event_name == 'schedule' || github.actor == github.repository_owner || github.actor == 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout xadupre.github.io
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Record ONNX Runtime PR activity
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python -u scripts/record_pr_activity.py
+
+      - name: Commit and push cache data
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add cache_data/onnxruntime/pr_activity.csv
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+          git commit -m "Update onnxruntime PR activity cache"
+          branch="${GITHUB_REF_NAME:-main}"
+          attempts=5
+          for i in $(seq 1 "$attempts"); do
+            push_err="$(mktemp)"
+            if git push origin "HEAD:${branch}" 2> >(tee "$push_err" >&2); then
+              rm -f "$push_err"
+              exit 0
+            fi
+            if grep -qE "error: 403|Permission to .* denied" "$push_err"; then
+              rm -f "$push_err"
+              echo "Push rejected by GitHub with HTTP 403." >&2
+              exit 1
+            fi
+            rm -f "$push_err"
+            git fetch origin "${branch}"
+            if ! git rebase -X ours "origin/${branch}"; then
+              git rebase --abort || true
+              exit 1
+            fi
+            sleep $((i * 5))
+          done
+          echo "Failed to push after ${attempts} attempts." >&2
+          exit 1

--- a/assets/workflow-manifest.json
+++ b/assets/workflow-manifest.json
@@ -127,6 +127,13 @@
   },
   {
     "crons": [
+      "53 4 * * 1"
+    ],
+    "name": "DATA onnxruntime PR activity",
+    "path": ".github/workflows/record_onnxruntime_pr_activity.yml"
+  },
+  {
+    "crons": [
       "42 4 * * 1"
     ],
     "name": "DATA PR statistics",

--- a/cache_data/onnxruntime/pr_activity.csv
+++ b/cache_data/onnxruntime/pr_activity.csv
@@ -1,0 +1,2 @@
+date,open_prs,merged_prs_7d,avg_open_age_days
+2026-08-28T06:37:29Z,816,33,264.13

--- a/dashboard/onnxruntime/pr-activity.html
+++ b/dashboard/onnxruntime/pr-activity.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>ONNX Runtime pull request activity</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<link rel="icon" type="image/svg+xml" href="../../logo.svg" />
+<style>
+html, body { height: 100%; margin: 0; }
+body {
+  background: #0d1117;
+  color: #c9d1d9;
+  font-family: sans-serif;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 1.5em;
+  box-sizing: border-box;
+}
+a { color: #58a6ff; text-decoration: none; }
+a:hover { text-decoration: underline; }
+header { text-align: center; margin-bottom: 1em; }
+h1 { margin: 0.2em 0; font-size: 1.4em; }
+.nav { font-size: 0.9em; margin-bottom: 0.5em; }
+.summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(160px, 1fr));
+  gap: 0.8em;
+  width: 100%;
+  max-width: 1100px;
+  margin-bottom: 1em;
+}
+.metric, .chart-wrap, .observations {
+  background: rgba(22, 27, 34, 0.85);
+  border-radius: 12px;
+  box-sizing: border-box;
+}
+.metric { padding: 0.8em 1em; text-align: center; }
+.metric .label { color: #8b949e; font-size: 0.8em; }
+.metric .value { color: #79c0ff; font: bold 1.6em monospace; margin-top: 0.2em; }
+.chart-wrap, .observations {
+  padding: 1em;
+  width: 100%;
+  max-width: 1100px;
+  margin-bottom: 1em;
+}
+.chart-container { position: relative; height: 38vh; min-height: 280px; }
+.chart-title { font-size: 1em; margin: 0 0 0.5em; text-align: center; }
+.hint, .description { color: #8b949e; font-size: 0.8em; text-align: center; }
+.description { max-width: 900px; margin: 0 0 1em; }
+.message {
+  display: none;
+  padding: 1em;
+  width: 100%;
+  max-width: 1100px;
+  box-sizing: border-box;
+  text-align: center;
+}
+.message.visible { display: block; }
+.message.error { color: #f85149; }
+.observations { overflow-x: auto; }
+.observations h2 { font-size: 1em; margin: 0 0 0.5em; }
+table { width: 100%; border-collapse: collapse; font-size: 0.85em; }
+th, td {
+  padding: 0.4em 0.6em;
+  border-bottom: 1px solid rgba(139, 148, 158, 0.25);
+  text-align: right;
+}
+th:first-child, td:first-child { text-align: left; }
+th { color: #8b949e; font-weight: normal; }
+td { font-family: monospace; }
+@media (max-width: 650px) {
+  .summary { grid-template-columns: 1fr; }
+}
+</style>
+<script src="../../assets/chart-loader.js"></script>
+</head>
+<body>
+<header>
+  <div class="nav"><a href="../../index.html">&larr; back to home</a></div>
+  <h1>ONNX Runtime &mdash; weekly pull request activity</h1>
+</header>
+<p class="description">
+  Weekly snapshots of <a href="https://github.com/microsoft/onnxruntime/pulls">microsoft/onnxruntime</a>.
+  The merged count covers the seven days preceding each snapshot; open PR age
+  is measured from creation time to the snapshot.
+</p>
+<div class="notice" style="max-width:1100px;width:100%;margin:0 auto 1em;padding:0.5em 1em;border-radius:8px;background:rgba(210,153,34,0.12);border:1px solid rgba(210,153,34,0.5);color:#d29922;font-size:0.85em;text-align:center;box-sizing:border-box;">⚠ The results displayed on this page are indicative and experimental.</div>
+<div id="message" class="message"></div>
+<div id="summary" class="summary" style="display:none;">
+  <div class="metric"><div class="label">open PRs</div><div id="latestOpen" class="value">0</div></div>
+  <div class="metric"><div class="label">merged in preceding 7 days</div><div id="latestMerged" class="value">0</div></div>
+  <div class="metric"><div class="label">average age of open PRs</div><div id="latestAge" class="value">0 days</div></div>
+</div>
+<div class="chart-wrap">
+  <h2 class="chart-title">open and merged pull requests</h2>
+  <div class="chart-container"><canvas id="chartCounts"></canvas></div>
+  <div class="hint">Drag to pan, mouse wheel or pinch to zoom. Double-click to reset.</div>
+</div>
+<div class="chart-wrap">
+  <h2 class="chart-title">average age of open pull requests</h2>
+  <div class="chart-container"><canvas id="chartAge"></canvas></div>
+  <div class="hint">Age in days at each weekly snapshot.</div>
+</div>
+<div id="observations" class="observations" style="display:none;">
+  <h2>Latest snapshots</h2>
+  <table>
+    <thead><tr><th>date</th><th>open PRs</th><th>merged (7d)</th><th>average open age (days)</th></tr></thead>
+    <tbody id="observationsBody"></tbody>
+  </table>
+</div>
+<footer class="data-updated" data-source="../../cache_data/onnxruntime/pr_activity.csv" style="margin:1em auto 0.5em;font-size:0.75em;color:#8b949e;text-align:center;display:none;"></footer>
+<script src="../../assets/last-updated.js"></script>
+<script>
+const CSV_URL = "../../cache_data/onnxruntime/pr_activity.csv";
+
+function showError(text) {
+  const message = document.getElementById("message");
+  message.textContent = text;
+  message.className = "message visible error";
+}
+
+function parseCSV(text) {
+  const lines = text.trim().split(/\r?\n/);
+  if (lines.length < 2) return [];
+  const header = lines.shift().split(",");
+  const index = {
+    date: header.indexOf("date"),
+    open: header.indexOf("open_prs"),
+    merged: header.indexOf("merged_prs_7d"),
+    age: header.indexOf("avg_open_age_days"),
+  };
+  return lines.map(line => {
+    const columns = line.split(",");
+    return {
+      date: columns[index.date],
+      open: Number(columns[index.open]),
+      merged: Number(columns[index.merged]),
+      age: Number(columns[index.age]),
+    };
+  }).filter(row =>
+    row.date && Number.isFinite(row.open) &&
+    Number.isFinite(row.merged) && Number.isFinite(row.age)
+  ).sort((a, b) => new Date(a.date) - new Date(b.date));
+}
+
+const commonOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  interaction: { mode: "nearest", intersect: false },
+  plugins: {
+    legend: { labels: { color: "#c9d1d9" } },
+    zoom: {
+      pan: { enabled: true, mode: "xy" },
+      zoom: { wheel: { enabled: true }, pinch: { enabled: true }, mode: "xy" },
+    },
+  },
+  scales: {
+    x: {
+      type: "time",
+      time: { unit: "week", tooltipFormat: "yyyy-MM-dd" },
+      ticks: { color: "#c9d1d9" },
+      grid: { color: "rgba(139,148,158,0.25)" },
+    },
+    y: {
+      beginAtZero: true,
+      ticks: { color: "#c9d1d9" },
+      grid: { color: "rgba(139,148,158,0.25)" },
+    },
+  },
+};
+
+function render(rows) {
+  const latest = rows[rows.length - 1];
+  document.getElementById("latestOpen").textContent = latest.open.toLocaleString();
+  document.getElementById("latestMerged").textContent = latest.merged.toLocaleString();
+  document.getElementById("latestAge").textContent = latest.age.toFixed(1) + " days";
+  document.getElementById("summary").style.display = "";
+
+  const points = (key) => rows.map(row => ({ x: row.date, y: row[key] }));
+  new Chart(document.getElementById("chartCounts"), {
+    type: "line",
+    data: { datasets: [
+      { label: "open PRs", data: points("open"), borderColor: "#58a6ff", backgroundColor: "#58a6ff", tension: 0.15 },
+      { label: "merged in preceding 7 days", data: points("merged"), borderColor: "#3fb950", backgroundColor: "#3fb950", tension: 0.15 },
+    ] },
+    options: commonOptions,
+  });
+  new Chart(document.getElementById("chartAge"), {
+    type: "line",
+    data: { datasets: [
+      { label: "average age (days)", data: points("age"), borderColor: "#d2a8ff", backgroundColor: "#d2a8ff", tension: 0.15 },
+    ] },
+    options: commonOptions,
+  });
+
+  const body = document.getElementById("observationsBody");
+  for (const row of rows.slice(-12).reverse()) {
+    const tr = document.createElement("tr");
+    for (const value of [
+      row.date.slice(0, 10),
+      row.open.toLocaleString(),
+      row.merged.toLocaleString(),
+      row.age.toFixed(2),
+    ]) {
+      const td = document.createElement("td");
+      td.textContent = value;
+      tr.appendChild(td);
+    }
+    body.appendChild(tr);
+  }
+  document.getElementById("observations").style.display = "";
+}
+
+for (const id of ["chartCounts", "chartAge"]) {
+  document.getElementById(id).addEventListener("dblclick", event => {
+    const chart = Chart.getChart(event.currentTarget);
+    if (chart) chart.resetZoom();
+  });
+}
+
+loadChartJs()
+  .then(() => fetch(CSV_URL, { cache: "no-store" }))
+  .then(response => {
+    if (!response.ok) throw new Error("HTTP " + response.status);
+    return response.text();
+  })
+  .then(text => {
+    const rows = parseCSV(text);
+    if (!rows.length) throw new Error("No PR activity snapshots are available.");
+    render(rows);
+  })
+  .catch(error => showError("Unable to load PR activity data: " + error.message));
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -608,6 +608,36 @@ main ul {
     </div>
   </div>
   <div class="grid-project">
+    <a href="https://github.com/microsoft/onnxruntime">
+      <img class="project-logo" src="https://raw.githubusercontent.com/microsoft/onnxruntime/main/docs/images/ONNX_Runtime_logo_dark.png" alt="ONNX Runtime logo" />
+      <span>onnxruntime</span>
+    </a>
+  </div>
+  <div class="grid-summary">
+    <p class="project-summary">weekly tracking of open and merged pull requests, including the average age of PRs that remain open</p>
+  </div>
+  <div class="grid-docs">
+    <div class="doc-links">
+      <a class="doc-link" href="dashboard/onnxruntime/pr-activity.html" title="ONNX Runtime weekly pull request activity" aria-label="ONNX Runtime weekly pull request activity dashboard" data-word="PRS">
+      <svg class="doc-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" aria-hidden="true">
+        <rect x="2" y="2" width="28" height="28" rx="5" fill="#0366d6"/>
+        <circle cx="10" cy="9" r="2.5" fill="none" stroke="#ffffff" stroke-width="1.8"/>
+        <circle cx="10" cy="23" r="2.5" fill="none" stroke="#ffffff" stroke-width="1.8"/>
+        <circle cx="22" cy="23" r="2.5" fill="none" stroke="#ffffff" stroke-width="1.8"/>
+        <line x1="10" y1="11.5" x2="10" y2="20.5" stroke="#ffffff" stroke-width="1.8"/>
+        <path d="M22 20.5 V14 a3 3 0 0 0 -3 -3 H14" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
+        <polyline points="16,8 13,11 16,14" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+      <span class="doc-label">PRs</span>
+    </a>
+    </div>
+  </div>
+  <div class="grid-badges">
+    <div class="project-badges">
+      <a href="https://github.com/xadupre/xadupre.github.io/actions/workflows/record_onnxruntime_pr_activity.yml" title="DATA onnxruntime PR activity"><img src="https://github.com/xadupre/xadupre.github.io/actions/workflows/record_onnxruntime_pr_activity.yml/badge.svg" alt="DATA onnxruntime PR activity" /></a>
+    </div>
+  </div>
+  <div class="grid-project">
     <a href="https://github.com/xadupre/onnx-light">
       <img class="project-logo" src="https://raw.githubusercontent.com/xadupre/onnx-light/main/docs/_static/logo.svg" alt="onnx-light logo" />
       <span>onnx-light</span>

--- a/scripts/record_pr_activity.py
+++ b/scripts/record_pr_activity.py
@@ -1,0 +1,149 @@
+"""Record a weekly snapshot of pull request activity for ONNX Runtime.
+
+The snapshot contains the current number of open pull requests, the number
+merged during the preceding seven days, and the average age in days of the
+pull requests that are still open. Rows are stored in
+``cache_data/onnxruntime/pr_activity.csv``.
+
+Usage::
+
+    python scripts/record_pr_activity.py [--cache-dir DIR]
+        [--repo owner/name]
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import os
+import urllib.parse
+from collections.abc import Iterator
+
+from record_build_durations import GITHUB_API, _format_iso, _log, _parse_iso, _request
+
+DEFAULT_REPO = "microsoft/onnxruntime"
+CSV_FIELDS = ("date", "open_prs", "merged_prs_7d", "avg_open_age_days")
+
+
+def iter_pulls(repo: str, state: str, token: str | None) -> Iterator[dict]:
+    """Yield pull requests in descending update order."""
+    page = 1
+    per_page = 100
+    while True:
+        params = {
+            "state": state,
+            "sort": "updated",
+            "direction": "desc",
+            "per_page": str(per_page),
+            "page": str(page),
+        }
+        url = f"{GITHUB_API}/repos/{repo}/pulls?" + urllib.parse.urlencode(params)
+        payload, _ = _request(url, token)
+        if not isinstance(payload, list) or not payload:
+            return
+        yield from payload
+        if len(payload) < per_page:
+            return
+        page += 1
+
+
+def collect_snapshot(
+    repo: str,
+    token: str | None,
+    now: dt.datetime | None = None,
+) -> dict[str, str]:
+    """Collect the current PR activity metrics for ``repo``."""
+    if now is None:
+        now = dt.datetime.now(tz=dt.timezone.utc)
+    elif now.tzinfo is None:
+        now = now.replace(tzinfo=dt.timezone.utc)
+    else:
+        now = now.astimezone(dt.timezone.utc)
+
+    open_pulls = list(iter_pulls(repo, "open", token))
+    ages = []
+    for pr in open_pulls:
+        created_at = pr.get("created_at")
+        if not created_at:
+            continue
+        try:
+            created = _parse_iso(created_at)
+        except ValueError:
+            continue
+        ages.append(max(0.0, (now - created).total_seconds() / 86400))
+
+    since = now - dt.timedelta(days=7)
+    merged = 0
+    for pr in iter_pulls(repo, "closed", token):
+        updated_at = pr.get("updated_at")
+        if updated_at:
+            try:
+                if _parse_iso(updated_at) < since:
+                    break
+            except ValueError:
+                pass
+        merged_at = pr.get("merged_at")
+        if not merged_at:
+            continue
+        try:
+            if _parse_iso(merged_at) >= since:
+                merged += 1
+        except ValueError:
+            continue
+
+    average_age = sum(ages) / len(ages) if ages else 0.0
+    return {
+        "date": _format_iso(now),
+        "open_prs": str(len(open_pulls)),
+        "merged_prs_7d": str(merged),
+        "avg_open_age_days": f"{average_age:.2f}",
+    }
+
+
+def write_snapshot(csv_path: str, snapshot: dict[str, str]) -> None:
+    """Insert or replace the snapshot for its UTC calendar date."""
+    rows: list[dict[str, str]] = []
+    snapshot_day = snapshot["date"][:10]
+    if os.path.exists(csv_path):
+        with open(csv_path, newline="", encoding="utf-8") as stream:
+            rows = [
+                row
+                for row in csv.DictReader(stream)
+                if (row.get("date") or "")[:10] != snapshot_day
+            ]
+    rows.append(snapshot)
+    rows.sort(key=lambda row: row["date"])
+    os.makedirs(os.path.dirname(csv_path), exist_ok=True)
+    with open(csv_path, "w", newline="", encoding="utf-8") as stream:
+        writer = csv.DictWriter(stream, fieldnames=CSV_FIELDS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--cache-dir",
+        default=os.path.join(os.path.dirname(os.path.dirname(__file__)), "cache_data"),
+        help="Path to the cache_data directory.",
+    )
+    parser.add_argument("--repo", default=DEFAULT_REPO, help="Repository to track.")
+    args = parser.parse_args(argv)
+
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    repo_name = args.repo.split("/", 1)[-1]
+    csv_path = os.path.join(args.cache_dir, repo_name, "pr_activity.csv")
+    _log(f"collecting weekly PR activity for {args.repo}")
+    snapshot = collect_snapshot(args.repo, token)
+    write_snapshot(csv_path, snapshot)
+    _log(
+        f"saved {csv_path}: open={snapshot['open_prs']}, "
+        f"merged_7d={snapshot['merged_prs_7d']}, "
+        f"average_open_age={snapshot['avg_open_age_days']} days"
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/tests/test_chart_loader.py
+++ b/scripts/tests/test_chart_loader.py
@@ -21,6 +21,7 @@ CHART_LOADER_PAGES = [
     ("dashboard/onnx/stats.html", 2),
     ("dashboard/onnx/build-durations.html", 2),
     ("dashboard/onnx/lost-compute.html", 2),
+    ("dashboard/onnxruntime/pr-activity.html", 2),
     ("dashboard/onnx-light/package-size.html", 2),
     ("dashboard/onnx-light/pr-stats.html", 2),
     ("dashboard/onnx-light/build-durations.html", 2),

--- a/scripts/tests/test_last_updated_footer.py
+++ b/scripts/tests/test_last_updated_footer.py
@@ -18,6 +18,7 @@ PAGES = [
     ("dashboard/onnx/stats.html", 2),
     ("dashboard/onnx/backend-test-coverage.html", 2),
     ("dashboard/onnx/build-durations.html", 2),
+    ("dashboard/onnxruntime/pr-activity.html", 2),
     ("dashboard/onnx-light/backend-test-coverage.html", 2),
     ("dashboard/onnx-light/build-durations.html", 2),
     ("dashboard/onnx-light/package-size.html", 2),

--- a/scripts/tests/test_record_pr_activity.py
+++ b/scripts/tests/test_record_pr_activity.py
@@ -1,0 +1,124 @@
+"""Tests for ``scripts.record_pr_activity``."""
+
+from __future__ import annotations
+
+import csv
+import datetime as dt
+import os
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(HERE))
+
+import record_pr_activity as rpa
+
+
+class TestRecordPrActivity(unittest.TestCase):
+    def test_dashboard_and_home_page_are_wired(self):
+        root = os.path.dirname(os.path.dirname(HERE))
+        page = os.path.join(root, "dashboard", "onnxruntime", "pr-activity.html")
+        with open(page, encoding="utf-8") as stream:
+            text = stream.read()
+        self.assertIn("open_prs", text)
+        self.assertIn("merged_prs_7d", text)
+        self.assertIn("avg_open_age_days", text)
+        self.assertIn("loadChartJs()", text)
+
+        with open(os.path.join(root, "index.html"), encoding="utf-8") as stream:
+            index = stream.read()
+        self.assertIn('href="dashboard/onnxruntime/pr-activity.html"', index)
+        self.assertIn("record_onnxruntime_pr_activity.yml", index)
+
+    def test_workflow_runs_the_recorder(self):
+        root = os.path.dirname(os.path.dirname(HERE))
+        workflow = os.path.join(
+            root, ".github", "workflows", "record_onnxruntime_pr_activity.yml"
+        )
+        with open(workflow, encoding="utf-8") as stream:
+            text = stream.read()
+        self.assertIn('cron: "53 4 * * 1"', text)
+        self.assertIn("python -u scripts/record_pr_activity.py", text)
+        self.assertIn("cache_data/onnxruntime/pr_activity.csv", text)
+
+    def test_collect_snapshot(self):
+        now = dt.datetime(2026, 8, 28, 8, tzinfo=dt.timezone.utc)
+        responses = {
+            "open": [
+                {
+                    "created_at": "2026-08-18T08:00:00Z",
+                    "updated_at": "2026-08-28T07:00:00Z",
+                },
+                {
+                    "created_at": "2026-08-08T08:00:00Z",
+                    "updated_at": "2026-08-27T07:00:00Z",
+                },
+            ],
+            "closed": [
+                {
+                    "merged_at": "2026-08-27T08:00:00Z",
+                    "updated_at": "2026-08-27T08:00:00Z",
+                },
+                {
+                    "merged_at": None,
+                    "updated_at": "2026-08-26T08:00:00Z",
+                },
+                {
+                    "merged_at": "2026-08-20T07:59:00Z",
+                    "updated_at": "2026-08-20T07:59:00Z",
+                },
+            ],
+        }
+
+        original = rpa.iter_pulls
+        rpa.iter_pulls = lambda repo, state, token: iter(responses[state])
+        try:
+            snapshot = rpa.collect_snapshot("owner/repo", None, now)
+        finally:
+            rpa.iter_pulls = original
+
+        self.assertEqual(snapshot["date"], "2026-08-28T08:00:00Z")
+        self.assertEqual(snapshot["open_prs"], "2")
+        self.assertEqual(snapshot["merged_prs_7d"], "1")
+        self.assertEqual(snapshot["avg_open_age_days"], "15.00")
+
+    def test_iter_pulls_handles_pagination(self):
+        calls = []
+
+        def fake_request(url, token):
+            page = int(url.rsplit("page=", 1)[1])
+            calls.append(page)
+            return ([{"number": page}] * (100 if page == 1 else 1), {})
+
+        original = rpa._request
+        rpa._request = fake_request
+        try:
+            pulls = list(rpa.iter_pulls("owner/repo", "open", None))
+        finally:
+            rpa._request = original
+        self.assertEqual(len(pulls), 101)
+        self.assertEqual(calls, [1, 2])
+
+    def test_write_snapshot_replaces_same_day(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "onnxruntime", "pr_activity.csv")
+            first = {
+                "date": "2026-08-28T08:00:00Z",
+                "open_prs": "100",
+                "merged_prs_7d": "20",
+                "avg_open_age_days": "30.00",
+            }
+            second = dict(first, date="2026-08-28T09:00:00Z", open_prs="101")
+            rpa.write_snapshot(path, first)
+            rpa.write_snapshot(path, second)
+            with open(path, newline="", encoding="utf-8") as stream:
+                rows = list(csv.DictReader(stream))
+            self.assertEqual(rows, [second])
+
+    def test_default_repository_is_onnxruntime(self):
+        self.assertEqual(rpa.DEFAULT_REPO, "microsoft/onnxruntime")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a weekly ONNX Runtime PR activity dashboard
- track the current open PR count, PRs merged during the preceding seven days, and average age of open PRs
- add a scheduled collector workflow and expose the dashboard from the home page
- seed the dashboard with an initial snapshot

Initial snapshot: 816 open PRs, 33 merged during the preceding seven days, and 264.13 days average open age.