### PR TITLE
Add ONNX PR activity dashboard

### DIFF
--- a/.github/workflows/record_onnx_pr_activity.yml
+++ b/.github/workflows/record_onnx_pr_activity.yml
@@ -1,0 +1,73 @@
+name: DATA onnx PR activity
+
+# Records a weekly snapshot of open and recently merged pull requests in
+# onnx/onnx for dashboard/onnx/pr-activity.html.
+
+on:
+  schedule:
+    - cron: "7 5 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  record:
+    if: github.event_name == 'schedule' || github.actor == github.repository_owner || github.actor == 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout xadupre.github.io
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Record ONNX PR activity
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python -u scripts/record_pr_activity.py --repo onnx/onnx
+
+      - name: Commit and push cache data
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add cache_data/onnx/pr_activity.csv
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+          git commit -m "Update onnx PR activity cache"
+          branch="${GITHUB_REF_NAME:-main}"
+          attempts=5
+          for i in $(seq 1 "$attempts"); do
+            push_err="$(mktemp)"
+            if git push origin "HEAD:${branch}" 2> >(tee "$push_err" >&2); then
+              rm -f "$push_err"
+              exit 0
+            fi
+            if grep -qE "error: 403|Permission to .* denied" "$push_err"; then
+              rm -f "$push_err"
+              echo "Push rejected by GitHub with HTTP 403." >&2
+              exit 1
+            fi
+            rm -f "$push_err"
+            git fetch origin "${branch}"
+            if ! git rebase -X ours "origin/${branch}"; then
+              git rebase --abort || true
+              exit 1
+            fi
+            sleep $((i * 5))
+          done
+          echo "Failed to push after ${attempts} attempts." >&2
+          exit 1

--- a/assets/workflow-manifest.json
+++ b/assets/workflow-manifest.json
@@ -29,6 +29,13 @@
   },
   {
     "crons": [
+      "7 5 * * 1"
+    ],
+    "name": "DATA onnx PR activity",
+    "path": ".github/workflows/record_onnx_pr_activity.yml"
+  },
+  {
+    "crons": [
       "17 6 * * 1"
     ],
     "name": "DATA onnx stats",

--- a/cache_data/onnx/pr_activity.csv
+++ b/cache_data/onnx/pr_activity.csv
@@ -1,0 +1,2 @@
+date,open_prs,merged_prs_7d,avg_open_age_days
+2026-08-28T06:45:24Z,108,17,135.36

--- a/dashboard/onnx/pr-activity.html
+++ b/dashboard/onnx/pr-activity.html
@@ -1,0 +1,192 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>ONNX pull request activity</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<link rel="icon" type="image/svg+xml" href="../../logo.svg" />
+<style>
+html, body { height: 100%; margin: 0; }
+body {
+  background: #0d1117; color: #c9d1d9; font-family: sans-serif;
+  min-height: 100vh; display: flex; flex-direction: column;
+  align-items: center; padding: 1.5em; box-sizing: border-box;
+}
+a { color: #58a6ff; text-decoration: none; }
+a:hover { text-decoration: underline; }
+header { text-align: center; margin-bottom: 1em; }
+h1 { margin: 0.2em 0; font-size: 1.4em; }
+.nav { font-size: 0.9em; margin-bottom: 0.5em; }
+.description, .hint { color: #8b949e; font-size: 0.8em; text-align: center; }
+.description { max-width: 900px; margin: 0 0 1em; }
+.summary {
+  display: grid; grid-template-columns: repeat(3, minmax(160px, 1fr));
+  gap: 0.8em; width: 100%; max-width: 1100px; margin-bottom: 1em;
+}
+.metric, .chart-wrap, .observations {
+  background: rgba(22, 27, 34, 0.85); border-radius: 12px; box-sizing: border-box;
+}
+.metric { padding: 0.8em 1em; text-align: center; }
+.metric .label { color: #8b949e; font-size: 0.8em; }
+.metric .value { color: #79c0ff; font: bold 1.6em monospace; margin-top: 0.2em; }
+.chart-wrap, .observations {
+  padding: 1em; width: 100%; max-width: 1100px; margin-bottom: 1em;
+}
+.chart-container { position: relative; height: 38vh; min-height: 280px; }
+.chart-title { font-size: 1em; margin: 0 0 0.5em; text-align: center; }
+.message { display: none; padding: 1em; text-align: center; }
+.message.visible { display: block; }
+.message.error { color: #f85149; }
+.observations { overflow-x: auto; }
+.observations h2 { font-size: 1em; margin: 0 0 0.5em; }
+table { width: 100%; border-collapse: collapse; font-size: 0.85em; }
+th, td {
+  padding: 0.4em 0.6em; border-bottom: 1px solid rgba(139, 148, 158, 0.25);
+  text-align: right;
+}
+th:first-child, td:first-child { text-align: left; }
+th { color: #8b949e; font-weight: normal; }
+td { font-family: monospace; }
+@media (max-width: 650px) { .summary { grid-template-columns: 1fr; } }
+</style>
+<script src="../../assets/chart-loader.js"></script>
+</head>
+<body>
+<header>
+  <div class="nav"><a href="../../index.html">&larr; back to home</a></div>
+  <h1>ONNX &mdash; weekly pull request activity</h1>
+</header>
+<p class="description">
+  Weekly snapshots of <a href="https://github.com/onnx/onnx/pulls">onnx/onnx</a>.
+  The merged count covers the seven days preceding each snapshot; open PR age
+  is measured from creation time to the snapshot.
+</p>
+<div class="notice" style="max-width:1100px;width:100%;margin:0 auto 1em;padding:0.5em 1em;border-radius:8px;background:rgba(210,153,34,0.12);border:1px solid rgba(210,153,34,0.5);color:#d29922;font-size:0.85em;text-align:center;box-sizing:border-box;">⚠ The results displayed on this page are indicative and experimental.</div>
+<div id="message" class="message"></div>
+<div id="summary" class="summary" style="display:none;">
+  <div class="metric"><div class="label">open PRs</div><div id="latestOpen" class="value">0</div></div>
+  <div class="metric"><div class="label">merged in preceding 7 days</div><div id="latestMerged" class="value">0</div></div>
+  <div class="metric"><div class="label">average age of open PRs</div><div id="latestAge" class="value">0 days</div></div>
+</div>
+<div class="chart-wrap">
+  <h2 class="chart-title">open and merged pull requests</h2>
+  <div class="chart-container"><canvas id="chartCounts"></canvas></div>
+  <div class="hint">Drag to pan, mouse wheel or pinch to zoom. Double-click to reset.</div>
+</div>
+<div class="chart-wrap">
+  <h2 class="chart-title">average age of open pull requests</h2>
+  <div class="chart-container"><canvas id="chartAge"></canvas></div>
+  <div class="hint">Age in days at each weekly snapshot.</div>
+</div>
+<div id="observations" class="observations" style="display:none;">
+  <h2>Latest snapshots</h2>
+  <table>
+    <thead><tr><th>date</th><th>open PRs</th><th>merged (7d)</th><th>average open age (days)</th></tr></thead>
+    <tbody id="observationsBody"></tbody>
+  </table>
+</div>
+<footer class="data-updated" data-source="../../cache_data/onnx/pr_activity.csv" style="margin:1em auto 0.5em;font-size:0.75em;color:#8b949e;text-align:center;display:none;"></footer>
+<script src="../../assets/last-updated.js"></script>
+<script>
+const CSV_URL = "../../cache_data/onnx/pr_activity.csv";
+
+function parseCSV(text) {
+  const lines = text.trim().split(/\r?\n/);
+  if (lines.length < 2) return [];
+  const header = lines.shift().split(",");
+  const column = name => header.indexOf(name);
+  return lines.map(line => {
+    const cells = line.split(",");
+    return {
+      date: cells[column("date")],
+      open: Number(cells[column("open_prs")]),
+      merged: Number(cells[column("merged_prs_7d")]),
+      age: Number(cells[column("avg_open_age_days")]),
+    };
+  }).filter(row => row.date && ["open", "merged", "age"].every(key => Number.isFinite(row[key])))
+    .sort((a, b) => new Date(a.date) - new Date(b.date));
+}
+
+const options = {
+  responsive: true, maintainAspectRatio: false,
+  interaction: { mode: "nearest", intersect: false },
+  plugins: {
+    legend: { labels: { color: "#c9d1d9" } },
+    zoom: {
+      pan: { enabled: true, mode: "xy" },
+      zoom: { wheel: { enabled: true }, pinch: { enabled: true }, mode: "xy" },
+    },
+  },
+  scales: {
+    x: {
+      type: "time", time: { unit: "week", tooltipFormat: "yyyy-MM-dd" },
+      ticks: { color: "#c9d1d9" }, grid: { color: "rgba(139,148,158,0.25)" },
+    },
+    y: {
+      beginAtZero: true, ticks: { color: "#c9d1d9" },
+      grid: { color: "rgba(139,148,158,0.25)" },
+    },
+  },
+};
+
+function render(rows) {
+  const latest = rows[rows.length - 1];
+  document.getElementById("latestOpen").textContent = latest.open.toLocaleString();
+  document.getElementById("latestMerged").textContent = latest.merged.toLocaleString();
+  document.getElementById("latestAge").textContent = latest.age.toFixed(1) + " days";
+  document.getElementById("summary").style.display = "";
+  const points = key => rows.map(row => ({ x: row.date, y: row[key] }));
+  new Chart(document.getElementById("chartCounts"), {
+    type: "line",
+    data: { datasets: [
+      { label: "open PRs", data: points("open"), borderColor: "#58a6ff", backgroundColor: "#58a6ff", tension: 0.15 },
+      { label: "merged in preceding 7 days", data: points("merged"), borderColor: "#3fb950", backgroundColor: "#3fb950", tension: 0.15 },
+    ] },
+    options,
+  });
+  new Chart(document.getElementById("chartAge"), {
+    type: "line",
+    data: { datasets: [
+      { label: "average age (days)", data: points("age"), borderColor: "#d2a8ff", backgroundColor: "#d2a8ff", tension: 0.15 },
+    ] },
+    options,
+  });
+  const body = document.getElementById("observationsBody");
+  for (const row of rows.slice(-12).reverse()) {
+    const tr = document.createElement("tr");
+    for (const value of [row.date.slice(0, 10), row.open, row.merged, row.age.toFixed(2)]) {
+      const td = document.createElement("td");
+      td.textContent = value.toLocaleString();
+      tr.appendChild(td);
+    }
+    body.appendChild(tr);
+  }
+  document.getElementById("observations").style.display = "";
+}
+
+for (const id of ["chartCounts", "chartAge"]) {
+  document.getElementById(id).addEventListener("dblclick", event => {
+    const chart = Chart.getChart(event.currentTarget);
+    if (chart) chart.resetZoom();
+  });
+}
+
+loadChartJs()
+  .then(() => fetch(CSV_URL, { cache: "no-store" }))
+  .then(response => {
+    if (!response.ok) throw new Error("HTTP " + response.status);
+    return response.text();
+  })
+  .then(text => {
+    const rows = parseCSV(text);
+    if (!rows.length) throw new Error("No PR activity snapshots are available.");
+    render(rows);
+  })
+  .catch(error => {
+    const message = document.getElementById("message");
+    message.textContent = "Unable to load PR activity data: " + error.message;
+    message.className = "message visible error";
+  });
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -557,7 +557,7 @@ main ul {
     </a>
   </div>
   <div class="grid-summary">
-    <p class="project-summary">weekly statistics gathered from the latest onnx release on PyPI (wheel size, opset, operator/test counts)</p>
+    <p class="project-summary">weekly release statistics and pull request activity for onnx</p>
   </div>
   <div class="grid-docs">
     <div class="doc-links">
@@ -569,6 +569,18 @@ main ul {
         <rect x="21" y="7" width="4" height="19" fill="#ffffff"/>
       </svg>
       <span class="doc-label">stats</span>
+    </a>
+    <a class="doc-link" href="dashboard/onnx/pr-activity.html" title="ONNX weekly pull request activity" aria-label="ONNX weekly pull request activity dashboard" data-word="PRS">
+      <svg class="doc-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" aria-hidden="true">
+        <rect x="2" y="2" width="28" height="28" rx="5" fill="#0366d6"/>
+        <circle cx="10" cy="9" r="2.5" fill="none" stroke="#ffffff" stroke-width="1.8"/>
+        <circle cx="10" cy="23" r="2.5" fill="none" stroke="#ffffff" stroke-width="1.8"/>
+        <circle cx="22" cy="23" r="2.5" fill="none" stroke="#ffffff" stroke-width="1.8"/>
+        <line x1="10" y1="11.5" x2="10" y2="20.5" stroke="#ffffff" stroke-width="1.8"/>
+        <path d="M22 20.5 V14 a3 3 0 0 0 -3 -3 H14" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
+        <polyline points="16,8 13,11 16,14" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+      <span class="doc-label">PRs</span>
     </a>
     <a class="doc-link" href="dashboard/onnx/build-durations.html" title="onnx CI job durations dashboard" aria-label="onnx CI job durations dashboard" data-word="DURATIONS">
       <svg class="doc-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" aria-hidden="true">
@@ -603,6 +615,7 @@ main ul {
   <div class="grid-badges">
     <div class="project-badges">
       <a href="https://github.com/xadupre/xadupre.github.io/actions/workflows/record_onnx_backend_node_coverage.yml" title="DATA onnx backend node test coverage"><img src="https://github.com/xadupre/xadupre.github.io/actions/workflows/record_onnx_backend_node_coverage.yml/badge.svg" alt="DATA onnx backend node test coverage" /></a>
+      <a href="https://github.com/xadupre/xadupre.github.io/actions/workflows/record_onnx_pr_activity.yml" title="DATA onnx PR activity"><img src="https://github.com/xadupre/xadupre.github.io/actions/workflows/record_onnx_pr_activity.yml/badge.svg" alt="DATA onnx PR activity" /></a>
       <a href="https://github.com/xadupre/xadupre.github.io/actions/workflows/record_onnx_stats.yml" title="DATA onnx stats"><img src="https://github.com/xadupre/xadupre.github.io/actions/workflows/record_onnx_stats.yml/badge.svg" alt="DATA onnx stats" /></a>
       <a href="https://github.com/xadupre/xadupre.github.io/actions/workflows/record_pypi_downloads.yml" title="DATA PyPI downloads"><img src="https://github.com/xadupre/xadupre.github.io/actions/workflows/record_pypi_downloads.yml/badge.svg" alt="DATA PyPI downloads" /></a>
     </div>

--- a/scripts/tests/test_chart_loader.py
+++ b/scripts/tests/test_chart_loader.py
@@ -19,6 +19,7 @@ REPO_ROOT = os.path.normpath(os.path.join(HERE, "..", ".."))
 CHART_LOADER_PAGES = [
     ("dashboard/pypi-downloads.html", 1),
     ("dashboard/onnx/stats.html", 2),
+    ("dashboard/onnx/pr-activity.html", 2),
     ("dashboard/onnx/build-durations.html", 2),
     ("dashboard/onnx/lost-compute.html", 2),
     ("dashboard/onnxruntime/pr-activity.html", 2),

--- a/scripts/tests/test_last_updated_footer.py
+++ b/scripts/tests/test_last_updated_footer.py
@@ -16,6 +16,7 @@ PAGES = [
     ("dashboard/pypi-downloads.html", 1),
     ("dashboard/mbext/class-coverage.html", 2),
     ("dashboard/onnx/stats.html", 2),
+    ("dashboard/onnx/pr-activity.html", 2),
     ("dashboard/onnx/backend-test-coverage.html", 2),
     ("dashboard/onnx/build-durations.html", 2),
     ("dashboard/onnxruntime/pr-activity.html", 2),

--- a/scripts/tests/test_record_pr_activity.py
+++ b/scripts/tests/test_record_pr_activity.py
@@ -18,17 +18,20 @@ import record_pr_activity as rpa
 class TestRecordPrActivity(unittest.TestCase):
     def test_dashboard_and_home_page_are_wired(self):
         root = os.path.dirname(os.path.dirname(HERE))
-        page = os.path.join(root, "dashboard", "onnxruntime", "pr-activity.html")
-        with open(page, encoding="utf-8") as stream:
-            text = stream.read()
-        self.assertIn("open_prs", text)
-        self.assertIn("merged_prs_7d", text)
-        self.assertIn("avg_open_age_days", text)
-        self.assertIn("loadChartJs()", text)
+        for project in ("onnx", "onnxruntime"):
+            page = os.path.join(root, "dashboard", project, "pr-activity.html")
+            with open(page, encoding="utf-8") as stream:
+                text = stream.read()
+            self.assertIn("open_prs", text)
+            self.assertIn("merged_prs_7d", text)
+            self.assertIn("avg_open_age_days", text)
+            self.assertIn("loadChartJs()", text)
 
         with open(os.path.join(root, "index.html"), encoding="utf-8") as stream:
             index = stream.read()
+        self.assertIn('href="dashboard/onnx/pr-activity.html"', index)
         self.assertIn('href="dashboard/onnxruntime/pr-activity.html"', index)
+        self.assertIn("record_onnx_pr_activity.yml", index)
         self.assertIn("record_onnxruntime_pr_activity.yml", index)
 
     def test_workflow_runs_the_recorder(self):
@@ -41,6 +44,17 @@ class TestRecordPrActivity(unittest.TestCase):
         self.assertIn('cron: "53 4 * * 1"', text)
         self.assertIn("python -u scripts/record_pr_activity.py", text)
         self.assertIn("cache_data/onnxruntime/pr_activity.csv", text)
+
+        onnx_workflow = os.path.join(
+            root, ".github", "workflows", "record_onnx_pr_activity.yml"
+        )
+        with open(onnx_workflow, encoding="utf-8") as stream:
+            text = stream.read()
+        self.assertIn('cron: "7 5 * * 1"', text)
+        self.assertIn(
+            "python -u scripts/record_pr_activity.py --repo onnx/onnx", text
+        )
+        self.assertIn("cache_data/onnx/pr_activity.csv", text)
 
     def test_collect_snapshot(self):
         now = dt.datetime(2026, 8, 28, 8, tzinfo=dt.timezone.utc)


### PR DESCRIPTION
## Summary

- add the same weekly PR activity dashboard for onnx/onnx as for microsoft/onnxruntime
- track open PRs, PRs merged during the preceding seven days, and average age of open PRs
- add a dedicated scheduled workflow and link the page from the ONNX project card
- seed the dashboard with its first snapshot

Initial snapshot: 108 open PRs, 17 merged during the preceding seven days, and 135.36 days average open age.