### PR TITLE
Split onnx-light-cpu benchmarks by data type

### DIFF
--- a/.github/workflows/record_onnx_light_cpu_examples_benchmark.yml
+++ b/.github/workflows/record_onnx_light_cpu_examples_benchmark.yml
@@ -1,30 +1,96 @@
 name: DATA onnx-light-cpu benchmark
 
-# Weekly job that runs the benchmark-tagged C++ backend tests registered by
-# onnx-light-cpu and measures them with onnxruntime and onnx-light-cpu, then
-# caches the results as JSON
+# Jobs spread across the week run the benchmark-tagged C++ backend tests
+# registered by onnx-light-cpu, one data type at a time, and measure them with
+# onnxruntime and onnx-light-cpu, then cache the merged results as JSON
 # under ``cache_data/onnx-light-cpu/examples_benchmark.json``. The dashboard at
 # ``dashboard/onnx-light-cpu/cpu-benchmark.html`` consumes that file.
 
 on:
   schedule:
-    # Run once a week, Monday at 08:41 UTC. The odd minute avoids the load
-    # spikes that happen exactly on the hour, and the offset from the
-    # onnx-light benchmark workflow (08:13) avoids competing for the same
-    # runner slot.
+    # Two types per weekday and one per weekend day, all at odd minutes to
+    # avoid load spikes exactly on the hour.
     - cron: "41 8 * * 1"
+    - cron: "41 20 * * 1"
+    - cron: "41 8 * * 2"
+    - cron: "41 20 * * 2"
+    - cron: "41 8 * * 3"
+    - cron: "41 20 * * 3"
+    - cron: "41 8 * * 4"
+    - cron: "41 20 * * 4"
+    - cron: "41 8 * * 5"
+    - cron: "41 20 * * 5"
+    - cron: "41 8 * * 6"
+    - cron: "41 8 * * 0"
   workflow_dispatch:
-
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: true
+    inputs:
+      type:
+        description: Data type to benchmark
+        required: true
+        type: choice
+        options:
+          - float32
+          - float64
+          - float16
+          - bfloat16
+          - int4
+          - int8
+          - int16
+          - int32
+          - int64
+          - uint8
+          - uint16
+          - uint32
 
 permissions:
   contents: write
 
 jobs:
+  select-type:
+    runs-on: ubuntu-latest
+    outputs:
+      type: ${{ steps.select.outputs.type }}
+    steps:
+      - name: Select benchmark type
+        id: select
+        env:
+          REQUESTED_TYPE: ${{ inputs.type }}
+          SCHEDULE: ${{ github.event.schedule }}
+        run: |
+          if [ -n "${REQUESTED_TYPE}" ]; then
+            type="${REQUESTED_TYPE}"
+          else
+            case "${SCHEDULE}" in
+              "41 8 * * 1") type=float32 ;;
+              "41 20 * * 1") type=float64 ;;
+              "41 8 * * 2") type=float16 ;;
+              "41 20 * * 2") type=bfloat16 ;;
+              "41 8 * * 3") type=int4 ;;
+              "41 20 * * 3") type=int8 ;;
+              "41 8 * * 4") type=int16 ;;
+              "41 20 * * 4") type=int32 ;;
+              "41 8 * * 5") type=int64 ;;
+              "41 20 * * 5") type=uint8 ;;
+              "41 8 * * 6") type=uint16 ;;
+              "41 8 * * 0") type=uint32 ;;
+              *)
+                echo "Unsupported schedule: ${SCHEDULE}" >&2
+                exit 1
+                ;;
+            esac
+          fi
+          echo "Selected benchmark type: ${type}"
+          echo "type=${type}" >> "$GITHUB_OUTPUT"
+
   record:
-    if: github.event_name == 'schedule' || github.actor == github.repository_owner || github.actor == 'github-actions[bot]'
+    needs: select-type
+    name: record (${{ needs.select-type.outputs.type }})
+    if: >-
+      github.event_name == 'schedule' || github.actor == github.repository_owner ||
+      github.actor == 'github-actions[bot]'
+    concurrency:
+      group: ${{ github.workflow }}-${{ needs.select-type.outputs.type }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     timeout-minutes: 240
     steps:
@@ -121,7 +187,8 @@ jobs:
 
       - name: Record benchmark snapshot
         run: |
-          python -u scripts/record_onnx_light_cpu_benchmark.py
+          python -u scripts/record_onnx_light_cpu_benchmark.py \
+            --type "${{ needs.select-type.outputs.type }}"
 
       - name: Commit and push cache data
         run: |

--- a/assets/workflow-manifest.json
+++ b/assets/workflow-manifest.json
@@ -113,7 +113,18 @@
   },
   {
     "crons": [
-      "41 8 * * 1"
+      "41 8 * * 1",
+      "41 20 * * 1",
+      "41 8 * * 2",
+      "41 20 * * 2",
+      "41 8 * * 3",
+      "41 20 * * 3",
+      "41 8 * * 4",
+      "41 20 * * 4",
+      "41 8 * * 5",
+      "41 20 * * 5",
+      "41 8 * * 6",
+      "41 8 * * 0"
     ],
     "name": "DATA onnx-light-cpu benchmark",
     "path": ".github/workflows/record_onnx_light_cpu_examples_benchmark.yml"

--- a/scripts/record_onnx_light_cpu_benchmark.py
+++ b/scripts/record_onnx_light_cpu_benchmark.py
@@ -22,6 +22,20 @@ from typing import Any
 import record_onnx_light_benchmark as rlb
 
 BENCHMARK_BACKENDS = ("onnx_light_cpu", "onnxruntime")
+BENCHMARK_TYPES = (
+    "float32",
+    "float64",
+    "float16",
+    "bfloat16",
+    "int4",
+    "int8",
+    "int16",
+    "int32",
+    "int64",
+    "uint8",
+    "uint16",
+    "uint32",
+)
 N_WARMUP = 2
 N_MEASURE = rlb.N_MEASURE
 MAX_WARMUP_TIME_S = 0.05
@@ -49,7 +63,19 @@ def _collect_benchmark_cases() -> list[Any]:
     return collect_test_cases(include_big=True, mode=TestMode.BENCHMARK)
 
 
-def discover_benchmark_tests(kind: str = "node") -> list[dict[str, Any]]:
+def benchmark_type_from_name(name: str) -> str | None:
+    """Return the recognized type whose occurrence starts first in *name*."""
+    matches = (
+        (position, type_name)
+        for type_name in BENCHMARK_TYPES
+        if (position := name.find(type_name)) >= 0
+    )
+    return min(matches, default=(0, None))[1]
+
+
+def discover_benchmark_tests(
+    kind: str = "node", benchmark_type: str | None = None
+) -> list[dict[str, Any]]:
     """Return only benchmark-tagged cases registered by onnx-light-cpu."""
     from onnx_light_cpu import register_backend_test_cases
 
@@ -60,6 +86,10 @@ def discover_benchmark_tests(kind: str = "node") -> list[dict[str, Any]]:
         for test in _collect_benchmark_cases()
         if str(test.name).startswith("test_cpu_")
         and str(test.name).endswith("_benchmark")
+        and (
+            benchmark_type is None
+            or benchmark_type_from_name(str(test.name)) == benchmark_type
+        )
         and (not kinds or getattr(test, "kind", None) in kinds)
     ]
 
@@ -296,6 +326,7 @@ def run_tests(
 
 def build_payload(
     kind: str = "node",
+    benchmark_type: str | None = None,
     limit: int | None = None,
     n_warmup: int = N_WARMUP,
     n_measure: int = N_MEASURE,
@@ -307,7 +338,7 @@ def build_payload(
     now: dt.datetime | None = None,
 ) -> dict[str, Any]:
     """Discover, run, and format the onnx-light-cpu benchmark tests."""
-    tests = discover(kind)
+    tests = discover(kind, benchmark_type)
     if limit is not None:
         tests = tests[: max(0, limit)]
     from onnx_light_cpu.onnx_py._cpukernels import detect_simd_level
@@ -340,10 +371,50 @@ def write_payload(path: str, payload: dict[str, Any]) -> None:
         stream.write("\n")
 
 
+def merge_payload(
+    previous: dict[str, Any],
+    current: dict[str, Any],
+    benchmark_type: str | None,
+) -> dict[str, Any]:
+    """Replace one type in a previous payload with freshly measured examples."""
+    if benchmark_type is None:
+        return current
+    retained = [
+        example
+        for example in previous.get("examples", [])
+        if not any(
+            benchmark_type_from_name(str(row.get("test_name", "")))
+            == benchmark_type
+            for row in example.get("rows", [])
+        )
+    ]
+    merged = dict(current)
+    merged["examples"] = sorted(
+        retained + current["examples"],
+        key=lambda example: (
+            str(example.get("op", "")).lower(),
+            str(example.get("rows", [{}])[0].get("input_type", "")).lower(),
+        ),
+    )
+    return merged
+
+
+def load_payload(path: str) -> dict[str, Any]:
+    """Load an existing benchmark payload."""
+    if not os.path.exists(path):
+        return {}
+    with open(path, encoding="utf-8") as stream:
+        payload = json.load(stream)
+    if not isinstance(payload, dict):
+        raise TypeError(f"Expected a JSON object in {path!r}.")
+    return payload
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--cache-dir", default="cache_data")
     parser.add_argument("--kind", default="node")
+    parser.add_argument("--type", choices=BENCHMARK_TYPES)
     parser.add_argument("--limit", type=int)
     parser.add_argument("--n-warmup", type=int, default=N_WARMUP)
     parser.add_argument("--n-measure", type=int, default=N_MEASURE)
@@ -356,6 +427,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     payload = build_payload(
         kind=args.kind,
+        benchmark_type=args.type,
         limit=args.limit,
         n_warmup=args.n_warmup,
         n_measure=args.n_measure,
@@ -363,6 +435,7 @@ def main(argv: list[str] | None = None) -> int:
         max_repeat_time_s=args.max_repeat_time,
     )
     path = os.path.join(args.cache_dir, "onnx-light-cpu", "examples_benchmark.json")
+    payload = merge_payload(load_payload(path), payload, args.type)
     write_payload(path, payload)
     return 0
 

--- a/scripts/tests/test_examples_benchmark_dashboard.py
+++ b/scripts/tests/test_examples_benchmark_dashboard.py
@@ -242,6 +242,8 @@ class TestWorkflow(unittest.TestCase):
         self.assertNotIn("pip install onnx-light", text)
         self.assertNotIn("pip install onnx-light-cpu", text)
         self.assertIn("python -u scripts/record_onnx_light_cpu_benchmark.py", text)
+        self.assertIn('type: choice', text)
+        self.assertIn('--type "${{ needs.select-type.outputs.type }}"', text)
         self.assertIn("cache_data/onnx-light-cpu/examples_benchmark.json", text)
 
 

--- a/scripts/tests/test_record_onnx_light_cpu_benchmark.py
+++ b/scripts/tests/test_record_onnx_light_cpu_benchmark.py
@@ -40,6 +40,33 @@ class TestDiscovery(unittest.TestCase):
         self.assertEqual([test["name"] for test in tests], ["test_cpu_abs_benchmark"])
         self.assertNotIn("model", tests[0])
 
+    def test_filters_on_first_recognized_type_in_name(self):
+        module = types.ModuleType("onnx_light_cpu")
+        module.register_backend_test_cases = lambda: None
+        cases = [
+            types.SimpleNamespace(
+                name="test_cpu_cast_uint8_float32_benchmark", kind="node"
+            ),
+            types.SimpleNamespace(
+                name="test_cpu_cast_float32_uint8_benchmark", kind="node"
+            ),
+            types.SimpleNamespace(name="test_cpu_abs_bfloat16_benchmark", kind="node"),
+        ]
+        with (
+            patch.dict(sys.modules, {"onnx_light_cpu": module}),
+            patch.object(rcb, "_collect_benchmark_cases", lambda: cases),
+        ):
+            tests = rcb.discover_benchmark_tests(benchmark_type="uint8")
+
+        self.assertEqual(
+            [test["name"] for test in tests],
+            ["test_cpu_cast_uint8_float32_benchmark"],
+        )
+        self.assertEqual(
+            rcb.benchmark_type_from_name("test_cpu_abs_bfloat16_benchmark"),
+            "bfloat16",
+        )
+
 
 class TestLoading(unittest.TestCase):
     def test_loads_one_benchmark_case_by_exact_name(self):
@@ -161,6 +188,10 @@ class TestPayload(unittest.TestCase):
     def test_payload_uses_discovered_tests(self):
         calls = {}
 
+        def discover(kind, benchmark_type):
+            calls["discover"] = (kind, benchmark_type)
+            return [{"name": "test_cpu_abs_float32_benchmark"}]
+
         def run(
             tests,
             n_warmup,
@@ -180,7 +211,8 @@ class TestPayload(unittest.TestCase):
         sys.modules[cpu.__name__] = cpu
         try:
             payload = rcb.build_payload(
-                discover=lambda kind: [{"name": "test_cpu_abs_benchmark"}],
+                benchmark_type="float32",
+                discover=discover,
                 run=run,
                 versions=dict,
                 now=dt.datetime(2026, 1, 2, tzinfo=dt.timezone.utc),
@@ -190,7 +222,10 @@ class TestPayload(unittest.TestCase):
                 del sys.modules[cpu.__name__]
             else:
                 sys.modules[cpu.__name__] = original
-        self.assertEqual(calls["tests"], [{"name": "test_cpu_abs_benchmark"}])
+        self.assertEqual(calls["discover"], ("node", "float32"))
+        self.assertEqual(
+            calls["tests"], [{"name": "test_cpu_abs_float32_benchmark"}]
+        )
         self.assertEqual(calls["n_warmup"], 2)
         self.assertEqual(calls["max_warmup_time_s"], 0.05)
         self.assertEqual(calls["max_repeat_time_s"], rcb.MAX_REPEAT_TIME_S)
@@ -198,6 +233,52 @@ class TestPayload(unittest.TestCase):
         self.assertEqual(payload["max_repeat_time_s"], 0.2)
         self.assertEqual(payload["simd_name"], "AVX2")
         self.assertEqual(payload["date"], "2026-01-02T00:00:00Z")
+
+    def test_merge_payload_replaces_only_requested_type(self):
+        previous = {
+            "date": "old",
+            "examples": [
+                {
+                    "op": "Abs",
+                    "rows": [
+                        {
+                            "input_type": "float32",
+                            "test_name": "test_cpu_abs_float32_benchmark",
+                        }
+                    ],
+                },
+                {
+                    "op": "Add",
+                    "rows": [
+                        {
+                            "input_type": "int8",
+                            "test_name": "test_cpu_add_int8_benchmark",
+                        }
+                    ],
+                },
+            ],
+        }
+        current = {
+            "date": "new",
+            "examples": [
+                {
+                    "op": "Relu",
+                    "rows": [
+                        {
+                            "input_type": "float32",
+                            "test_name": "test_cpu_relu_float32_benchmark",
+                        }
+                    ],
+                }
+            ],
+        }
+
+        merged = rcb.merge_payload(previous, current, "float32")
+
+        self.assertEqual(merged["date"], "new")
+        self.assertEqual(
+            [example["op"] for example in merged["examples"]], ["Add", "Relu"]
+        )
 
     def test_run_tests_uses_global_backend_phases(self):
         model = types.SimpleNamespace(


### PR DESCRIPTION
## Summary
- add a required data-type choice to manual benchmark runs
- schedule the 12 supported data types across the week
- classify each case by the first recognized type substring in its name
- merge each type-specific result into the existing benchmark cache

## Tests
- `python -m unittest discover -s scripts/tests -p 'test_*benchmark*.py'`