### PR TITLE
Update backend test metadata API

### DIFF
--- a/scripts/backend_test_metadata.py
+++ b/scripts/backend_test_metadata.py
@@ -1,0 +1,37 @@
+"""Compatibility helpers for onnx-light backend-test metadata."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def metadata_name(value: Any, metadata_type: str) -> Any:
+    """Return the public metadata name, preserving legacy collections."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return value
+    try:
+        from onnx_light.onnx_py._onnxpybackend import backend_test
+    except ImportError:
+        backend_test = None
+    if backend_test is not None:
+        converter = getattr(backend_test, f"test_case_{metadata_type}_name", None)
+        if converter is not None:
+            try:
+                return str(converter(value))
+            except TypeError:
+                pass
+    return str(value)
+
+
+def kind_name(value: Any) -> str:
+    """Return the public string representation of a test-case kind."""
+    return metadata_name(value, "kind")
+
+
+def tag_name(value: Any) -> Any:
+    """Return the public string representation of a test-case tag."""
+    return metadata_name(value, "tag")

--- a/scripts/record_onnx_backend_node_coverage.py
+++ b/scripts/record_onnx_backend_node_coverage.py
@@ -47,6 +47,7 @@ if HERE not in sys.path:
     sys.path.insert(0, HERE)
 
 import record_onnx_backend_test_coverage as _base  # noqa: E402
+from backend_test_metadata import kind_name, tag_name  # noqa: E402
 
 DEFAULT_RTOL = _base.DEFAULT_RTOL
 DEFAULT_ATOL = _base.DEFAULT_ATOL
@@ -120,7 +121,7 @@ def discover_node_tests(kind: str = "node") -> List[Dict[str, Any]]:
     for name, tc in cases.items():
         if not name:
             continue
-        case_kind = getattr(tc, "kind", None)
+        case_kind = kind_name(getattr(tc, "kind", None))
         if kinds and case_kind not in kinds:
             continue
         model = getattr(tc, "model", None)
@@ -143,13 +144,13 @@ def discover_node_tests(kind: str = "node") -> List[Dict[str, Any]]:
             )
             for inputs, outputs in data_sets
         ]
-        tag = getattr(tc, "tag", None) or ""
+        tag = tag_name(getattr(tc, "tag", None))
         discovered.append(
             {
                 "name": str(name),
                 "model": onnx_model,
                 "data_sets": converted_data_sets,
-                "tag": str(tag),
+                "tag": tag,
             }
         )
     discovered.sort(key=lambda d: d["name"])

--- a/scripts/record_onnx_backend_test_coverage.py
+++ b/scripts/record_onnx_backend_test_coverage.py
@@ -40,6 +40,8 @@ import time
 import traceback
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+from backend_test_metadata import kind_name, tag_name
+
 BACKENDS: Tuple[str, ...] = (
     "onnxruntime",
     "reference",
@@ -253,7 +255,7 @@ def discover_node_tests(kind=DEFAULT_KIND) -> List[Dict[str, Any]]:
     for name, tc in cases.items():
         if not name:
             continue
-        case_kind = getattr(tc, "kind", None)
+        case_kind = kind_name(getattr(tc, "kind", None))
         if kinds and case_kind not in kinds:
             continue
         model = getattr(tc, "model", None)
@@ -281,13 +283,13 @@ def discover_node_tests(kind=DEFAULT_KIND) -> List[Dict[str, Any]]:
             )
             for inputs, outputs in data_sets
         ]
-        tag = getattr(tc, "tag", None) or ""
+        tag = tag_name(getattr(tc, "tag", None))
         discovered.append(
             {
                 "name": str(name),
                 "model": onnx_model,
                 "data_sets": converted_data_sets,
-                "tag": str(tag),
+                "tag": tag,
             }
         )
     discovered.sort(key=lambda d: d["name"])

--- a/scripts/record_onnx_constant_info_coverage.py
+++ b/scripts/record_onnx_constant_info_coverage.py
@@ -35,6 +35,8 @@ import sys
 import traceback
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+from backend_test_metadata import tag_name
+
 DEFAULT_TAGS: Tuple[str, ...] = ("constant",)
 DEFAULT_TAG: str = ",".join(DEFAULT_TAGS)
 # Metadata key written by onnx-light's ``write_constant_info_to_metadata``.
@@ -428,7 +430,7 @@ def discover_constant_info_tests(tag=DEFAULT_TAGS) -> List[Dict[str, Any]]:
     for name, tc in cases.items():
         if not name:
             continue
-        case_tags = _normalize_tags(getattr(tc, "tag", "") or "")
+        case_tags = _normalize_tags(tag_name(getattr(tc, "tag", None)))
         model = getattr(tc, "model", None)
         if model is None:
             continue

--- a/scripts/record_onnx_inplace_reuse_coverage.py
+++ b/scripts/record_onnx_inplace_reuse_coverage.py
@@ -29,6 +29,8 @@ import sys
 import traceback
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+from backend_test_metadata import tag_name
+
 DEFAULT_TAGS: Tuple[str, ...] = ("inplace",)
 DEFAULT_TAG: str = ",".join(DEFAULT_TAGS)
 METADATA_KEYS: Tuple[str, ...] = ("onnx_light.inplace_reuse",)
@@ -350,7 +352,7 @@ def discover_inplace_tests(tag=DEFAULT_TAGS) -> List[Dict[str, Any]]:
     for name, tc in cases.items():
         if not name:
             continue
-        case_tags = _normalize_tags(getattr(tc, "tag", "") or "")
+        case_tags = _normalize_tags(tag_name(getattr(tc, "tag", None)))
         model = getattr(tc, "model", None)
         if model is None:
             continue

--- a/scripts/record_onnx_light_benchmark.py
+++ b/scripts/record_onnx_light_benchmark.py
@@ -83,6 +83,8 @@ import time
 import traceback
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+from backend_test_metadata import kind_name, tag_name
+
 # ---------------------------------------------------------------------------
 # Configuration constants
 # ---------------------------------------------------------------------------
@@ -330,7 +332,7 @@ def _discover_benchmark_mode_tests(kind: str) -> Optional[List[Dict[str, Any]]]:
         # correctness inputs.
         if not str(name).endswith(BENCHMARK_NAME_SUFFIX):
             continue
-        case_kind = getattr(tc, "kind", None)
+        case_kind = kind_name(getattr(tc, "kind", None))
         if kinds and case_kind not in kinds:
             continue
         model = getattr(tc, "model", None)
@@ -340,13 +342,13 @@ def _discover_benchmark_mode_tests(kind: str) -> Optional[List[Dict[str, Any]]]:
         data_sets = _cc_data_sets_to_python(tc)
         if not data_sets:
             continue
-        tag = getattr(tc, "tag", None) or ""
+        tag = tag_name(getattr(tc, "tag", None))
         discovered.append(
             {
                 "name": str(name),
                 "model": onnx_model,
                 "data_sets": data_sets,
-                "tag": str(tag),
+                "tag": tag,
             }
         )
     discovered.sort(key=lambda d: d["name"])
@@ -524,7 +526,7 @@ def discover_node_tests(kind: str = DEFAULT_KIND) -> List[Dict[str, Any]]:
     for name, tc in cases.items():
         if not name:
             continue
-        case_kind = getattr(tc, "kind", None)
+        case_kind = kind_name(getattr(tc, "kind", None))
         if kinds and case_kind not in kinds:
             continue
         model = getattr(tc, "model", None)
@@ -547,13 +549,13 @@ def discover_node_tests(kind: str = DEFAULT_KIND) -> List[Dict[str, Any]]:
             )
             for inputs, outputs in data_sets
         ]
-        tag = getattr(tc, "tag", None) or ""
+        tag = tag_name(getattr(tc, "tag", None))
         discovered.append(
             {
                 "name": str(name),
                 "model": onnx_model,
                 "data_sets": converted_data_sets,
-                "tag": str(tag),
+                "tag": tag,
             }
         )
     discovered.sort(key=lambda d: d["name"])

--- a/scripts/record_onnx_light_cpu_benchmark.py
+++ b/scripts/record_onnx_light_cpu_benchmark.py
@@ -20,6 +20,7 @@ from collections.abc import Callable
 from typing import Any
 
 import record_onnx_light_benchmark as rlb
+from backend_test_metadata import kind_name
 
 BENCHMARK_BACKENDS = ("onnx_light_cpu", "onnxruntime")
 BENCHMARK_TYPES = (
@@ -90,7 +91,7 @@ def discover_benchmark_tests(
             benchmark_type is None
             or benchmark_type_from_name(str(test.name)) == benchmark_type
         )
-        and (not kinds or getattr(test, "kind", None) in kinds)
+        and (not kinds or kind_name(getattr(test, "kind", None)) in kinds)
     ]
 
 

--- a/scripts/record_onnx_release_after_coverage.py
+++ b/scripts/record_onnx_release_after_coverage.py
@@ -31,6 +31,8 @@ import sys
 import traceback
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+from backend_test_metadata import tag_name
+
 DEFAULT_TAGS: Tuple[str, ...] = ("release_after",)
 DEFAULT_TAG: str = ",".join(DEFAULT_TAGS)
 METADATA_KEYS: Tuple[str, ...] = (
@@ -425,7 +427,7 @@ def discover_release_after_tests(tag=DEFAULT_TAGS) -> List[Dict[str, Any]]:
     for name, tc in cases.items():
         if not name:
             continue
-        case_tags = _normalize_tags(getattr(tc, "tag", "") or "")
+        case_tags = _normalize_tags(tag_name(getattr(tc, "tag", None)))
         model = getattr(tc, "model", None)
         if model is None:
             continue

--- a/scripts/record_onnx_shape_inference_coverage.py
+++ b/scripts/record_onnx_shape_inference_coverage.py
@@ -53,6 +53,8 @@ import sys
 import traceback
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+from backend_test_metadata import tag_name
+
 # Order matters: it drives the column order in the dashboard.
 BACKENDS: Tuple[str, ...] = (
     "onnx-light",
@@ -424,7 +426,7 @@ def discover_inference_tests(tag=DEFAULT_TAGS) -> List[Dict[str, Any]]:
     for name, tc in cases.items():
         if not name:
             continue
-        case_tags = _normalize_tags(getattr(tc, "tag", "") or "")
+        case_tags = _normalize_tags(tag_name(getattr(tc, "tag", None)))
         if tags and not any(t in tags for t in case_tags):
             continue
         model = getattr(tc, "model", None)

--- a/scripts/record_onnx_shape_tag_coverage.py
+++ b/scripts/record_onnx_shape_tag_coverage.py
@@ -29,6 +29,8 @@ import sys
 import traceback
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+from backend_test_metadata import tag_name
+
 DEFAULT_TAGS: Tuple[str, ...] = ("shape_tag",)
 DEFAULT_TAG: str = ",".join(DEFAULT_TAGS)
 # Metadata keys written by onnx-light's ``write_value_and_node_tags_to_metadata``.
@@ -469,7 +471,7 @@ def discover_shape_tag_tests(tag=DEFAULT_TAGS) -> List[Dict[str, Any]]:
     for name, tc in cases.items():
         if not name:
             continue
-        case_tags = _normalize_tags(getattr(tc, "tag", "") or "")
+        case_tags = _normalize_tags(tag_name(getattr(tc, "tag", None)))
         model = getattr(tc, "model", None)
         if model is None:
             continue

--- a/scripts/record_onnx_stats.py
+++ b/scripts/record_onnx_stats.py
@@ -28,6 +28,8 @@ import sys
 import urllib.request
 from typing import Iterable
 
+from backend_test_metadata import kind_name
+
 PYPI_JSON_URL = "https://pypi.org/pypi/{package}/json"
 
 CSV_FIELDS = (
@@ -159,7 +161,7 @@ def count_node_test_cases() -> int:
         count = sum(
             1
             for name, tc in cases.items()
-            if name and getattr(tc, "kind", None) == "node"
+            if name and kind_name(getattr(tc, "kind", None)) == "node"
         )
         if count:
             return count

--- a/scripts/tests/test_backend_test_metadata.py
+++ b/scripts/tests/test_backend_test_metadata.py
@@ -1,0 +1,49 @@
+"""Tests for backend-test metadata compatibility helpers."""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(HERE))
+
+from backend_test_metadata import kind_name, tag_name
+
+
+class TestMetadataName(unittest.TestCase):
+    def test_preserves_legacy_strings(self):
+        self.assertEqual(kind_name("node"), "node")
+        self.assertEqual(tag_name("inference"), "inference")
+        self.assertEqual(tag_name(None), "")
+
+    def test_converts_native_enums_with_onnx_light_api(self):
+        node = object()
+        inference = object()
+        backend = types.ModuleType(
+            "onnx_light.onnx_py._onnxpybackend.backend_test"
+        )
+        backend.test_case_kind_name = lambda value: (
+            "node" if value is node else "model"
+        )
+        backend.test_case_tag_name = lambda value: (
+            "inference" if value is inference else ""
+        )
+        modules = {
+            "onnx_light": types.ModuleType("onnx_light"),
+            "onnx_light.onnx_py": types.ModuleType("onnx_light.onnx_py"),
+            "onnx_light.onnx_py._onnxpybackend": types.ModuleType(
+                "onnx_light.onnx_py._onnxpybackend"
+            ),
+            "onnx_light.onnx_py._onnxpybackend.backend_test": backend,
+        }
+        with patch.dict(sys.modules, modules):
+            self.assertEqual(kind_name(node), "node")
+            self.assertEqual(tag_name(inference), "inference")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- normalize the new native `TestCaseKind` and `TestCaseTag` enums through the onnx-light conversion API
- update coverage, benchmark, and statistics recorders that still compared metadata with strings
- preserve compatibility with legacy string and multi-tag test cases

## Validation
- `python -m pytest -q scripts/tests` (649 passed, 58 subtests passed)
- exercised enum conversion and unload/rematerialization against the current onnx-light checkout